### PR TITLE
Internals refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>nl.knaw.dans.shared</groupId>
 		<artifactId>dans-scala-prototype</artifactId>
-		<version>1.29</version>
+		<version>1.30</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.knaw.dans.easy</groupId>
@@ -93,7 +93,6 @@
 		<dependency>
 			<groupId>com.jsuereth</groupId>
 			<artifactId>scala-arm_2.11</artifactId>
-			<version>2.0-RC1</version>
 		</dependency>
 	</dependencies>
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 			<artifactId>velocity</artifactId>
 			<version>1.7</version>
 		</dependency>
+		<dependency>
+			<groupId>com.jsuereth</groupId>
+			<artifactId>scala-arm_2.11</artifactId>
+			<version>2.0-RC1</version>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>

--- a/src/main/scala/nl/knaw/dans/easy/license/FileAccessRight.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/FileAccessRight.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license.internal
+package nl.knaw.dans.easy.license
 
 // TODO replace this object with a 'commons-library-call' (see also EASY-Stage-FileItem)
 object FileAccessRight extends Enumeration {

--- a/src/main/scala/nl/knaw/dans/easy/license/LicenseCreator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/LicenseCreator.scala
@@ -32,17 +32,17 @@ class LicenseCreator(placeholderMapper: PlaceholderMapper,
   val log = LoggerFactory.getLogger(getClass)
 
   def createLicense(dataset: Dataset)(outputStream: OutputStream): Try[Unit] = {
-    new ByteArrayOutputStream()
-      .use(templateOut => {
+    resource.managed(new ByteArrayOutputStream())
+      .map(templateOut => {
         log.info(s"""creating the license for dataset "${dataset.datasetID}"""")
         for {
           placeholders <- placeholderMapper.datasetToPlaceholderMap(dataset.validate)
           _ <- templateResolver.createTemplate(templateOut, placeholders)
           pdfInput = new ByteArrayInputStream(templateOut.toByteArray)
-          _ <- pdfInput.use(pdfGenerator.createPdf(_, outputStream).!)
+          _ <- resource.managed(pdfInput).map(pdfGenerator.createPdf(_, outputStream).!).tried
         } yield ()
       })
-      .flatten
+      .acquireAndGet(identity)
   }
 }
 

--- a/src/main/scala/nl/knaw/dans/easy/license/LicenseCreator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/LicenseCreator.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.license
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, OutputStream}
 
+import nl.knaw.dans.easy.license.internal._
 import nl.knaw.dans.pf.language.emd.EasyMetadata
 import org.slf4j.LoggerFactory
 import rx.lang.scala.Observable

--- a/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
@@ -19,6 +19,7 @@ import java.io.File
 import javax.naming.ldap.LdapContext
 
 import com.yourmediashelf.fedora.client.FedoraClient
+import nl.knaw.dans.easy.license.internal.{DatasetID, Fedora, FedoraImpl, Ldap, LdapImpl}
 
 // this class needs to be in a separate file rather than in package.scala because of interop with
 // java business layer.

--- a/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
@@ -19,26 +19,22 @@ import java.io.File
 import javax.naming.ldap.LdapContext
 
 import com.yourmediashelf.fedora.client.FedoraClient
-import nl.knaw.dans.easy.license.internal.{DatasetID, Fedora, FedoraImpl, Ldap, LdapImpl}
+import nl.knaw.dans.easy.license.internal.{BaseParameters, DatasetID, FedoraImpl, LdapImpl, Parameters}
 
-// this class needs to be in a separate file rather than in package.scala because of interop with
-// java business layer.
-class BaseParameters(val templateResourceDir: File,
-                     val datasetID: DatasetID,
-                     val isSample: Boolean)
+object BaseParameters {
 
-trait DatabaseParameters {
-  val fedora: Fedora
-  val ldap: Ldap
+  def apply(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean) = {
+    new BaseParameters(templateResourceDir, datasetID, isSample)
+  }
 }
 
-case class Parameters(override val templateResourceDir: File,
-                      override val datasetID: DatasetID,
-                      override val isSample: Boolean,
-                      fedora: Fedora,
-                      ldap: Ldap)
-  extends BaseParameters(templateResourceDir, datasetID, isSample) with DatabaseParameters {
+object Parameters {
 
-  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext) =
-    this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext))
+  def apply(templateResourceDir: File,
+            datasetID: DatasetID,
+            isSample: Boolean,
+            fedoraClient: FedoraClient,
+            ldapContext: LdapContext) = {
+    new Parameters(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext))
+  }
 }

--- a/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
@@ -19,12 +19,12 @@ import java.io.File
 import javax.naming.ldap.LdapContext
 
 import com.yourmediashelf.fedora.client.FedoraClient
-import nl.knaw.dans.easy.license.internal.{BaseParameters, DatasetID, FedoraImpl, LdapImpl, Parameters}
+import nl.knaw.dans.easy.license.internal.DatasetID
 
 object BaseParameters {
 
   def apply(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean) = {
-    new BaseParameters(templateResourceDir, datasetID, isSample)
+    new internal.BaseParameters(templateResourceDir, datasetID, isSample)
   }
 }
 
@@ -35,6 +35,6 @@ object Parameters {
             isSample: Boolean,
             fedoraClient: FedoraClient,
             ldapContext: LdapContext) = {
-    new Parameters(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext))
+    new internal.Parameters(templateResourceDir, datasetID, isSample, fedoraClient, ldapContext)
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
@@ -15,11 +15,8 @@
  */
 package nl.knaw.dans.easy.license.app
 
-import java.io.FileOutputStream
-
 import nl.knaw.dans.easy.license.LicenseCreator
 import nl.knaw.dans.easy.license.app.{CommandLineOptions => cmd}
-import nl.knaw.dans.easy.license.internal.CloseableResourceExtensions
 import org.slf4j.LoggerFactory
 import rx.schedulers.Schedulers
 
@@ -34,8 +31,9 @@ object Command {
     try {
       implicit val (parameters, outputFile) = cmd.parse(args)
 
-      new FileOutputStream(outputFile)
-        .usedIn(LicenseCreator(parameters).createLicense)
+      resource.Using.fileOutputStream(outputFile)
+        .map(LicenseCreator(parameters).createLicense)
+        .acquireAndGet(identity)
         .doOnCompleted(log.info(s"license saved at ${outputFile.getAbsolutePath}"))
         .doOnTerminate {
           // close LDAP at the end of the main

--- a/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.easy.license.app
 
+import java.io.FileOutputStream
+
 import nl.knaw.dans.easy.license.LicenseCreator
 import nl.knaw.dans.easy.license.app.{CommandLineOptions => cmd}
+import nl.knaw.dans.easy.license.internal._
 import org.slf4j.LoggerFactory
 import rx.schedulers.Schedulers
 
@@ -31,9 +34,8 @@ object Command {
     try {
       implicit val (parameters, outputFile) = cmd.parse(args)
 
-      resource.Using.fileOutputStream(outputFile)
-        .map(LicenseCreator(parameters).createLicense)
-        .acquireAndGet(identity)
+      new FileOutputStream(outputFile)
+        .usedIn(LicenseCreator(parameters).createLicense)
         .doOnCompleted(log.info(s"license saved at ${outputFile.getAbsolutePath}"))
         .doOnTerminate {
           // close LDAP at the end of the main

--- a/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.app
 
 import java.io.FileOutputStream
 
-import nl.knaw.dans.easy.license.{CommandLineOptions => cmd}
+import nl.knaw.dans.easy.license.LicenseCreator
+import nl.knaw.dans.easy.license.app.{CommandLineOptions => cmd}
+import nl.knaw.dans.easy.license.internal.CloseableResourceExtensions
 import org.slf4j.LoggerFactory
 import rx.schedulers.Schedulers
 

--- a/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.app
 
 import java.io.File
 import javax.naming.Context
 import javax.naming.ldap.InitialLdapContext
 
 import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
+import nl.knaw.dans.easy.license.Parameters
+import nl.knaw.dans.easy.license.internal.{DatasetID, Version}
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.rogach.scallop._
 import org.slf4j.LoggerFactory

--- a/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
@@ -20,7 +20,8 @@ import javax.naming.Context
 import javax.naming.ldap.InitialLdapContext
 
 import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
-import nl.knaw.dans.easy.license.internal.{DatasetID, Parameters, Version}
+import nl.knaw.dans.easy.license.DatasetID
+import nl.knaw.dans.easy.license.internal.{Parameters, Version}
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.rogach.scallop._
 import org.slf4j.LoggerFactory

--- a/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
@@ -20,8 +20,7 @@ import javax.naming.Context
 import javax.naming.ldap.InitialLdapContext
 
 import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
-import nl.knaw.dans.easy.license.Parameters
-import nl.knaw.dans.easy.license.internal.{DatasetID, Version}
+import nl.knaw.dans.easy.license.internal.{DatasetID, Parameters, Version}
 import org.apache.commons.configuration.PropertiesConfiguration
 import org.rogach.scallop._
 import org.slf4j.LoggerFactory

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.license.internal
 
 import javax.naming.directory.Attributes
 
-import nl.knaw.dans.easy.license.DatabaseParameters
 import nl.knaw.dans.easy.license.internal.FileAccessRight.FileAccessRight
 import nl.knaw.dans.pf.language.emd.binding.EmdUnmarshaller
 import nl.knaw.dans.pf.language.emd.{EasyMetadata, EasyMetadataImpl, EmdAudience}

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
@@ -205,18 +205,20 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
   }
 
   def getUserById(depositorID: DepositorID): Observable[EasyUser] = {
-    ldap.query(depositorID)(implicit attrs => {
-      val name = getOrEmpty("displayname")
-      val org = getOrEmpty("o")
-      val addr = getOrEmpty("postaladdress")
-      val code = getOrEmpty("postalcode")
-      val place = getOrEmpty("l")
-      val country = getOrEmpty("st")
-      val phone = getOrEmpty("telephonenumber")
-      val mail = getOrEmpty("mail")
+    ldap.query(depositorID)
+      .map(implicit attrs => {
+        val name = getOrEmpty("displayname")
+        val org = getOrEmpty("o")
+        val addr = getOrEmpty("postaladdress")
+        val code = getOrEmpty("postalcode")
+        val place = getOrEmpty("l")
+        val country = getOrEmpty("st")
+        val phone = getOrEmpty("telephonenumber")
+        val mail = getOrEmpty("mail")
 
-      EasyUser(name, org, addr, code, place, country, phone, mail)
-    }).single
+        EasyUser(name, org, addr, code, place, country, phone, mail)
+      })
+      .single
   }
 }
 

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.license.internal
 
 import javax.naming.directory.Attributes
 
-import nl.knaw.dans.easy.license.internal.FileAccessRight.FileAccessRight
+import nl.knaw.dans.easy.license.{DatasetID, DepositorID, FileAccessRight, FileItem}
 import nl.knaw.dans.pf.language.emd.binding.EmdUnmarshaller
 import nl.knaw.dans.pf.language.emd.{EasyMetadata, EasyMetadataImpl, EmdAudience}
 import rx.lang.scala.schedulers.IOScheduler
@@ -64,8 +64,6 @@ case class Dataset(datasetID: DatasetID,
 
   def validate: Dataset = DatasetValidator.validate(this)
 }
-
-case class FileItem(path: String, accessibleTo: FileAccessRight, checkSum: String)
 
 trait DatasetLoader {
 

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import javax.naming.directory.Attributes
 
-import nl.knaw.dans.easy.license.FileAccessRight.FileAccessRight
+import nl.knaw.dans.easy.license.DatabaseParameters
+import nl.knaw.dans.easy.license.internal.FileAccessRight.FileAccessRight
 import nl.knaw.dans.pf.language.emd.binding.EmdUnmarshaller
 import nl.knaw.dans.pf.language.emd.{EasyMetadata, EasyMetadataImpl, EmdAudience}
-import rx.lang.scala.{Observable, ObservableExtensions}
 import rx.lang.scala.schedulers.IOScheduler
+import rx.lang.scala.{Observable, ObservableExtensions}
 
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
@@ -174,7 +175,7 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
   private def getFileItem(filePid: FileID): Observable[FileItem] = {
     val pathAndAccessCategory = fedora.getFileMetadata(filePid)(is => {
       val xml = is.loadXML
-      (xml \\ "path" text,
+      ((xml \\ "path").text,
         FileAccessRight.valueOf(xml \\ "accessibleTo" text)
           .getOrElse(throw new IllegalArgumentException(s"illegal value for accessibleTo in file: $filePid")))
     }).subscribeOn(IOScheduler())

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetValidator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetValidator.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 object DatasetValidator {
 

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Fedora.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Fedora.scala
@@ -20,6 +20,7 @@ import java.io.InputStream
 import com.yourmediashelf.fedora.client.request.RiSearch
 import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
 import com.yourmediashelf.fedora.generated.management.DatastreamProfile
+import nl.knaw.dans.easy.license.DatasetID
 import rx.lang.scala.Observable
 
 import scala.io.Source

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Fedora.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Fedora.scala
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import java.io.InputStream
 
-import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
 import com.yourmediashelf.fedora.client.request.RiSearch
+import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
 import com.yourmediashelf.fedora.generated.management.DatastreamProfile
 import rx.lang.scala.Observable
 

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/FileAccessRight.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/FileAccessRight.scala
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
-class DatasetValidatorSpec extends UnitSpec {
+// TODO replace this object with a 'commons-library-call' (see also EASY-Stage-FileItem)
+object FileAccessRight extends Enumeration {
+  type FileAccessRight = Value
 
-  "validate" should "replace null fields in easy-user with an empty string" in {
-    val depositor = new EasyUser("foo", null, "addr", "zipcode", "ct", null, null, "bar")
-    val expected = new EasyUser("foo", "", "addr", "zipcode", "ct", "", "", "bar")
+  val
+  ANONYMOUS,
+  KNOWN,
+  RESTRICTED_REQUEST,
+  RESTRICTED_GROUP,
+  NONE
+  = Value
 
-    DatasetValidator.validate(depositor) shouldBe expected
-  }
+  def valueOf(s: String) = FileAccessRight.values.find(_.toString == s)
 }

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/KeywordMapping.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/KeywordMapping.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 // @formatter:off
 trait KeywordMapping { val keyword: String }

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
@@ -25,11 +25,10 @@ import rx.lang.scala.Observable
 trait Ldap extends AutoCloseable {
 
   /**
-    * Queries LDAP for the user data corresponding to the given `depositorID` and transforms it
-    * into an instance of type `T` using the function `f`.
+    * Queries LDAP for the user data corresponding to the given `depositorID`
     *
     * @param depositorID the identifier related to the depositor
-    * @return the instance of `T` wrapped in an `Observable`
+    * @return the result of the query in key-value pairs
     */
   def query(depositorID: DepositorID): Observable[Attributes]
 }

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.license.internal
 
+import javax.naming.NamingEnumeration
 import javax.naming.directory.{Attributes, SearchControls}
 import javax.naming.ldap.LdapContext
 
@@ -28,16 +29,24 @@ trait Ldap extends AutoCloseable {
     * into an instance of type `T` using the function `f`.
     *
     * @param depositorID the identifier related to the depositor
-    * @param f function that transforms an `Attributes` object to an instance of type `T`
-    * @tparam T the result type of the transformer function
     * @return the instance of `T` wrapped in an `Observable`
     */
-  def query[T](depositorID: DepositorID)(f: Attributes => T): Observable[T]
+  def query(depositorID: DepositorID): Observable[Attributes]
 }
 
 case class LdapImpl(ctx: LdapContext) extends Ldap {
 
-  def query[T](depositorID: DepositorID)(f: Attributes => T) = {
+  implicit class NamingEnumerationToObservable[T](val enum: NamingEnumeration[T]) {
+    def toObservable = Observable.from(new Iterable[T] {
+      def iterator = new Iterator[T] {
+        def hasNext = enum.hasMore
+
+        def next() = enum.next()
+      }
+    })
+  }
+
+  def query(depositorID: DepositorID) = {
     Observable.defer {
       val searchFilter = s"(&(objectClass=easyUser)(uid=$depositorID))"
       val searchControls = {
@@ -48,7 +57,7 @@ case class LdapImpl(ctx: LdapContext) extends Ldap {
 
       ctx.search("dc=dans,dc=knaw,dc=nl", searchFilter, searchControls)
         .toObservable
-        .map(f compose (_.getAttributes))
+        .map(_.getAttributes)
     }
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import javax.naming.directory.{Attributes, SearchControls}
 import javax.naming.ldap.LdapContext

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.license.internal
 import javax.naming.directory.{Attributes, SearchControls}
 import javax.naming.ldap.LdapContext
 
+import nl.knaw.dans.easy.license.DepositorID
 import rx.lang.scala.Observable
 
 trait Ldap extends AutoCloseable {

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
@@ -19,6 +19,7 @@ import java.io.File
 import javax.naming.ldap.LdapContext
 
 import com.yourmediashelf.fedora.client.FedoraClient
+import nl.knaw.dans.easy.license.DatasetID
 
 // this class needs to be in a separate file rather than in package.scala because of interop with
 // java business layer.

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.license.internal
+
+import java.io.File
+import javax.naming.ldap.LdapContext
+
+import com.yourmediashelf.fedora.client.FedoraClient
+
+// this class needs to be in a separate file rather than in package.scala because of interop with
+// java business layer.
+class BaseParameters(val templateResourceDir: File,
+                     val datasetID: DatasetID,
+                     val isSample: Boolean)
+
+trait DatabaseParameters {
+  val fedora: Fedora
+  val ldap: Ldap
+}
+
+case class Parameters(override val templateResourceDir: File,
+                      override val datasetID: DatasetID,
+                      override val isSample: Boolean,
+                      fedora: Fedora,
+                      ldap: Ldap)
+  extends BaseParameters(templateResourceDir, datasetID, isSample) with DatabaseParameters {
+
+  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext) =
+    this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext))
+}

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
@@ -41,4 +41,6 @@ case class Parameters(override val templateResourceDir: File,
 
   def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext) =
     this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext))
+
+  override def toString = super.toString
 }

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/PdfGenerator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/PdfGenerator.scala
@@ -13,19 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
-// TODO replace this object with a 'commons-library-call' (see also EASY-Stage-FileItem)
-object FileAccessRight extends Enumeration {
-  type FileAccessRight = Value
+import java.io.{InputStream, OutputStream}
 
-  val
-  ANONYMOUS,
-  KNOWN,
-  RESTRICTED_REQUEST,
-  RESTRICTED_GROUP,
-  NONE
-  = Value
+import nl.knaw.dans.easy.license.BaseParameters
+import org.slf4j.LoggerFactory
 
-  def valueOf(s: String) = FileAccessRight.values.find(_.toString == s)
+import scala.sys.process._
+
+trait PdfGenerator {
+
+  def createPdf(input: InputStream, output: OutputStream): ProcessBuilder
+}
+
+class WeasyPrintPdfGenerator(implicit parameters: BaseParameters) extends PdfGenerator {
+
+  val log = LoggerFactory.getLogger(getClass)
+
+  def createPdf(input: InputStream, output: OutputStream): ProcessBuilder = {
+    log.debug("create pdf")
+
+    pdfRunScript.getAbsolutePath #< input #> output
+  }
 }

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/PdfGenerator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/PdfGenerator.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.license.internal
 
 import java.io.{InputStream, OutputStream}
 
-import nl.knaw.dans.easy.license.BaseParameters
 import org.slf4j.LoggerFactory
 
 import scala.sys.process._

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import java.io._
 import java.net.URLEncoder
@@ -21,7 +21,8 @@ import java.{util => ju}
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
-import nl.knaw.dans.easy.license.FileAccessRight._
+import nl.knaw.dans.easy.license.BaseParameters
+import nl.knaw.dans.easy.license.internal.FileAccessRight._
 import nl.knaw.dans.pf.language.emd.types.{IsoDate, MetadataItem}
 import nl.knaw.dans.pf.language.emd.{EasyMetadata, EmdDate, Term}
 import org.apache.commons.codec.binary.Base64

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
@@ -21,7 +21,6 @@ import java.{util => ju}
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
-import nl.knaw.dans.easy.license.BaseParameters
 import nl.knaw.dans.easy.license.internal.FileAccessRight._
 import nl.knaw.dans.pf.language.emd.types.{IsoDate, MetadataItem}
 import nl.knaw.dans.pf.language.emd.{EasyMetadata, EmdDate, Term}

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
@@ -21,7 +21,8 @@ import java.{util => ju}
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory
 import nl.knaw.dans.common.lang.dataset.AccessCategory._
-import nl.knaw.dans.easy.license.internal.FileAccessRight._
+import nl.knaw.dans.easy.license.{DatasetID, FileAccessRight, FileItem}
+import nl.knaw.dans.easy.license.FileAccessRight._
 import nl.knaw.dans.pf.language.emd.types.{IsoDate, MetadataItem}
 import nl.knaw.dans.pf.language.emd.{EasyMetadata, EmdDate, Term}
 import org.apache.commons.codec.binary.Base64

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import java.io.{File, OutputStream, OutputStreamWriter}
 import java.nio.charset.Charset
 import java.util.Properties
 
+import nl.knaw.dans.easy.license.BaseParameters
 import org.apache.velocity.VelocityContext
 import org.apache.velocity.app.VelocityEngine
 import org.slf4j.LoggerFactory

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
@@ -59,11 +59,13 @@ class VelocityTemplateResolver(properties: Properties)(implicit parameters: Base
   def createTemplate(out: OutputStream, map: PlaceholderMap, encoding: Charset = encoding) = {
     log.debug("resolve template placeholders")
 
-    new OutputStreamWriter(out, encoding).use(writer => {
-      val context = new VelocityContext
-      map.foreach { case (kw, o) => context.put(kw.keyword, o) }
+    resource.managed(new OutputStreamWriter(out, encoding))
+      .map(writer => {
+        val context = new VelocityContext
+        map.foreach { case (kw, o) => context.put(kw.keyword, o) }
 
-      engine.getTemplate(templateFileName, encoding.displayName()).merge(context, writer)
-    })
+        engine.getTemplate(templateFileName, encoding.displayName()).merge(context, writer)
+      })
+      .tried
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
@@ -19,7 +19,6 @@ import java.io.{File, OutputStream, OutputStreamWriter}
 import java.nio.charset.Charset
 import java.util.Properties
 
-import nl.knaw.dans.easy.license.BaseParameters
 import org.apache.velocity.VelocityContext
 import org.apache.velocity.app.VelocityEngine
 import org.slf4j.LoggerFactory

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -200,17 +200,6 @@ package object internal {
     })
   }
 
-  implicit class ReactiveResource[+T](val resource: ManagedResource[T]) extends AnyVal {
-    def observe: Observable[T] = {
-      try {
-        resource.acquireAndGet(Observable.just(_))
-      }
-      catch {
-        case e: Throwable => Observable.error(e)
-      }
-    }
-  }
-
   implicit class InputStreamExtensions(val stream: InputStream) extends AnyVal {
     def loadXML = XML load stream
   }

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy
+package nl.knaw.dans.easy.license
 
 import java.io._
 import java.nio.charset.Charset
@@ -30,7 +30,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 import scala.xml.XML
 
-package object license {
+package object internal {
 
   type DatasetID = String
   type DepositorID = String

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -189,15 +189,15 @@ package object internal {
     def emptyIfBlank = s.toOption.getOrElse("")
   }
 
-  implicit class NamingEnumerationToObservable[T](val enum: NamingEnumeration[T]) extends AnyVal {
-    def toObservable = Observable.from(new Iterable[T] {
-      def iterator = new Iterator[T] {
-        def hasNext = enum.hasMore
-
-        def next() = enum.next()
-      }
-    })
-  }
+//  implicit class NamingEnumerationToObservable[T](val enum: NamingEnumeration[T]) extends AnyVal {
+//    def toObservable = Observable.from(new Iterable[T] {
+//      def iterator = new Iterator[T] {
+//        def hasNext = enum.hasMore
+//
+//        def next() = enum.next()
+//      }
+//    })
+//  }
 
   implicit class InputStreamExtensions(val stream: InputStream) extends AnyVal {
     def loadXML = XML load stream

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -33,9 +33,6 @@ import scala.xml.XML
 
 package object internal {
 
-  type DatasetID = String
-  type DepositorID = String
-
   type AudienceID = String
   type AudienceTitle = String
 

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -18,7 +18,6 @@ package nl.knaw.dans.easy.license
 import java.io._
 import java.nio.charset.Charset
 import java.util.Properties
-import javax.naming.NamingEnumeration
 
 import org.apache.commons.io.{Charsets, FileUtils, IOUtils}
 import org.apache.commons.lang.StringUtils
@@ -188,16 +187,6 @@ package object internal {
 
     def emptyIfBlank = s.toOption.getOrElse("")
   }
-
-//  implicit class NamingEnumerationToObservable[T](val enum: NamingEnumeration[T]) extends AnyVal {
-//    def toObservable = Observable.from(new Iterable[T] {
-//      def iterator = new Iterator[T] {
-//        def hasNext = enum.hasMore
-//
-//        def next() = enum.next()
-//      }
-//    })
-//  }
 
   implicit class ReactiveResourceManager[T <: Closeable](val resource: T) extends AnyVal {
     def usedIn[S](observableFactory: T => Observable[S], dispose: T => Unit = _ => {}, disposeEagerly: Boolean = false): Observable[S] = {

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -23,7 +23,6 @@ import javax.naming.NamingEnumeration
 import org.apache.commons.io.{Charsets, FileUtils}
 import org.apache.commons.lang.StringUtils
 import org.slf4j.Logger
-import resource.ManagedResource
 import rx.lang.scala.Notification.{OnCompleted, OnError, OnNext}
 import rx.lang.scala.{Notification, Observable}
 

--- a/src/main/scala/nl/knaw/dans/easy/license/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/package.scala
@@ -13,27 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy
 
-import java.io.File
-import javax.naming.ldap.LdapContext
+import nl.knaw.dans.easy.license.FileAccessRight._
 
-import com.yourmediashelf.fedora.client.FedoraClient
+package object license {
 
-object BaseParameters {
+  type DatasetID = String
+  type DepositorID = String
 
-  def apply(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean) = {
-    new internal.BaseParameters(templateResourceDir, datasetID, isSample)
-  }
-}
-
-object Parameters {
-
-  def apply(templateResourceDir: File,
-            datasetID: DatasetID,
-            isSample: Boolean,
-            fedoraClient: FedoraClient,
-            ldapContext: LdapContext) = {
-    new internal.Parameters(templateResourceDir, datasetID, isSample, fedoraClient, ldapContext)
-  }
+  case class FileItem(path: String, accessibleTo: FileAccessRight, checkSum: String)
 }

--- a/src/test/resources/datasetloader/emd.xml
+++ b/src/test/resources/datasetloader/emd.xml
@@ -1,0 +1,9 @@
+<emd:easymetadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/" emd:version="0.1">
+    <emd:description>
+        <dc:description>descr foo bar</dc:description>
+    </emd:description>
+    <emd:audience>
+        <dct:audience eas:schemeId="custom.disciplines">aud1</dct:audience>
+        <dct:audience eas:schemeId="custom.disciplines">aud2</dct:audience>
+    </emd:audience>
+</emd:easymetadata>

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
@@ -20,7 +20,7 @@ import java.util
 import javax.naming.directory.Attributes
 
 import com.yourmediashelf.fedora.generated.management.DatastreamProfile
-import nl.knaw.dans.easy.license.{DatabaseParameters, UnitSpec}
+import nl.knaw.dans.easy.license.UnitSpec
 import nl.knaw.dans.pf.language.emd.Term.Name
 import nl.knaw.dans.pf.language.emd._
 import org.scalamock.scalatest.MockFactory

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
@@ -20,7 +20,7 @@ import java.util
 import javax.naming.directory.Attributes
 
 import com.yourmediashelf.fedora.generated.management.DatastreamProfile
-import nl.knaw.dans.easy.license.UnitSpec
+import nl.knaw.dans.easy.license._
 import nl.knaw.dans.pf.language.emd.Term.Name
 import nl.knaw.dans.pf.language.emd._
 import org.scalamock.scalatest.MockFactory

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
@@ -15,32 +15,26 @@
  */
 package nl.knaw.dans.easy.license.internal
 
-import java.io.InputStream
+import java.io.File
 import java.util
 import javax.naming.directory.BasicAttributes
 
 import com.yourmediashelf.fedora.generated.management.DatastreamProfile
 import nl.knaw.dans.easy.license._
-import nl.knaw.dans.pf.language.emd.Term.Name
 import nl.knaw.dans.pf.language.emd._
+import org.apache.commons.io.{FileUtils, IOUtils}
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import rx.lang.scala.Observable
 import rx.lang.scala.observers.TestSubscriber
 
+import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
 
-class DatasetLoaderSpec extends UnitSpec with MockFactory {
-
-  trait MockEasyMetadata extends EasyMetadataImpl {
-    override def toString(x: String, y: Name): String = ""
-    override def toString(x: String, y: Term): String = ""
-    override def toString(x: String, y: MDContainer): String = ""
-    override def toString(x: String): String = ""
-  }
+class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter with BeforeAndAfterAll {
 
   val fedoraMock = mock[Fedora]
   val ldapMock = mock[Ldap]
-  val emdMock = mock[MockEasyMetadata]
 
   val (userAttributes, expectedUser) = {
     val attrs = new BasicAttributes
@@ -62,6 +56,16 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory {
     val fedora: Fedora = fedoraMock
     val ldap: Ldap = ldapMock
   }
+
+  before {
+    new File(getClass.getResource("/datasetloader/").toURI).copyDir(new File(testDir, "datasetloader"))
+  }
+
+  after {
+    new File(testDir, "datasetloader").deleteDirectory()
+  }
+
+  override def afterAll = testDir.getParentFile.deleteDirectory()
 
   "getUserById" should "query the user data from ldap for a given user id" in {
     ldapMock.query _ expects "testID" returning Observable.just(userAttributes)
@@ -115,42 +119,43 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory {
     val id = "testID"
     val depID = "depID"
     val user = EasyUser("name", "org", "addr", "pc", "city", "cntr", "phone", "mail")
-    val audience = mock[EmdAudience]
     val audiences = Seq("aud1", "aud2")
     val files = Seq(
       FileItem("path1", FileAccessRight.RESTRICTED_GROUP, "chs1"),
       FileItem("path2", FileAccessRight.KNOWN, "chs2")
     )
-    val expected = Dataset(id, emdMock, user, audiences, files)
 
-    (fedoraMock.getAMD(_: String)(_: InputStream => String)) expects (id, *) returning Observable.just(depID)
-    (fedoraMock.getEMD(_: String)(_: InputStream => EasyMetadata)) expects (id, *) returning Observable.just(emdMock)
-    emdMock.getEmdAudience _ expects () returning audience
+    val amdStream = IOUtils.toInputStream(<foo><depositorId>{depID}</depositorId></foo>.toString)
+    val emdStream = FileUtils.openInputStream(new File(testDir, "datasetloader/emd.xml"))
+
+    fedoraMock.getAMD _ expects id returning Observable.just(amdStream)
+    fedoraMock.getEMD _ expects id returning Observable.just(emdStream)
 
     val loader = new DatasetLoaderImpl {
-      override def getUserById(depositorID: DepositorID): Observable[EasyUser] =
-      {
+      override def getUserById(depositorID: DepositorID): Observable[EasyUser] = {
         if (depositorID == depID) Observable.just(user)
         else fail(s"not the correct depositorID, was $depositorID, should be $depID")
       }
 
-      override def getAudiences(a: EmdAudience): Observable[AudienceTitle] =
-      {
-        if (a == audience) Observable.from(audiences)
+      override def getAudiences(a: EmdAudience): Observable[AudienceTitle] = {
+        if (a.getDisciplines.asScala.map(_.getValue) == audiences) Observable.from(audiences)
         else fail("not the correct audiences")
       }
 
-      override def getFilesInDataset(did: DatasetID): Observable[FileItem] =
-      {
+      override def getFilesInDataset(did: DatasetID): Observable[FileItem] = {
         if (did == id) Observable.from(files)
         else fail(s"not the correct datasetID, was $did, should be $id")
       }
     }
-    val testObserver = TestSubscriber[Dataset]()
-    loader.getDatasetById(id).subscribe(testObserver)
+    val testObserver = TestSubscriber[(DatasetID, Seq[String], EasyUser, Seq[AudienceTitle], Seq[FileItem])]()
+    loader.getDatasetById(id)
+      // there is no equals defined for the emd, so I need to unpack here
+      .map { case Dataset(datasetID, emd, usr, titles, fileItems) =>
+        (datasetID, emd.getEmdDescription.getDcDescription.asScala.map(_.getValue), usr, titles, fileItems) }
+      .subscribe(testObserver)
 
     testObserver.awaitTerminalEvent()
-    testObserver.assertValue(expected)
+    testObserver.assertValue((id, Seq("descr foo bar"), user, audiences, files))
     testObserver.assertNoErrors()
     testObserver.assertCompleted()
   }
@@ -162,11 +167,19 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory {
     val fi1@FileItem(path1, accTo1, chcksm1) = FileItem("path1", FileAccessRight.NONE, "chcksm1")
     val fi2@FileItem(path2, accTo2, chcksm2) = FileItem("path2", FileAccessRight.KNOWN, "chcksm2")
 
+    val pa1 = IOUtils.toInputStream(<foo><path>{path1}</path><accessibleTo>{accTo1}</accessibleTo></foo>.toString)
+    val pa2 = IOUtils.toInputStream(<foo><path>{path2}</path><accessibleTo>{accTo2}</accessibleTo></foo>.toString)
+
+    val dp1 = mock[DatastreamProfile]
+    val dp2 = mock[DatastreamProfile]
+
+    dp1.getDsChecksum _ expects () returning chcksm1
+    dp2.getDsChecksum _ expects () returning chcksm2
     fedoraMock.queryRiSearch _ expects where[String](_ contains id) returning Observable.just(pid1, pid2)
-    (fedoraMock.getFileMetadata(_: String)(_: InputStream => (String, FileAccessRight.Value))) expects (pid1, *) returning Observable.just((path1, accTo1))
-    (fedoraMock.getFileMetadata(_: String)(_: InputStream => (String, FileAccessRight.Value))) expects (pid2, *) returning Observable.just((path2, accTo2))
-    (fedoraMock.getFile(_: String)(_: DatastreamProfile => String)) expects (pid1, *) returning Observable.just(chcksm1)
-    (fedoraMock.getFile(_: String)(_: DatastreamProfile => String)) expects (pid2, *) returning Observable.just(chcksm2)
+    fedoraMock.getFileMetadata _ expects pid1 returning Observable.just(pa1)
+    fedoraMock.getFileMetadata _ expects pid2 returning Observable.just(pa2)
+    fedoraMock.getFile _ expects pid1 returning Observable.just(dp1)
+    fedoraMock.getFile _ expects pid2 returning Observable.just(dp2)
 
     val loader = DatasetLoaderImpl()
     val testObserver = TestSubscriber[Set[FileItem]]()
@@ -180,9 +193,10 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory {
   }
 
   "getAudience" should "search the title for each audienceID in the EmdAudience in Fedora" in {
+    val is = IOUtils.toInputStream(<foo><title>title1</title></foo>.toString)
     val (id1, title1) = ("id1", "title1")
 
-    (fedoraMock.getDC(_: String)(_: InputStream => String)) expects (id1, *) returning Observable.just(title1)
+    fedoraMock.getDC _ expects id1 returning Observable.just(is)
 
     val loader = DatasetLoaderImpl()
     val testObserver = TestSubscriber[String]()

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetValidatorSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetValidatorSpec.scala
@@ -13,26 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
-import java.io.{InputStream, OutputStream}
+import nl.knaw.dans.easy.license.UnitSpec
 
-import org.slf4j.LoggerFactory
+class DatasetValidatorSpec extends UnitSpec {
 
-import scala.sys.process._
+  "validate" should "replace null fields in easy-user with an empty string" in {
+    val depositor = EasyUser("foo", null, "addr", "zipcode", "ct", null, null, "bar")
+    val expected = EasyUser("foo", "", "addr", "zipcode", "ct", "", "", "bar")
 
-trait PdfGenerator {
-
-  def createPdf(input: InputStream, output: OutputStream): ProcessBuilder
-}
-
-class WeasyPrintPdfGenerator(implicit parameters: BaseParameters) extends PdfGenerator {
-
-  val log = LoggerFactory.getLogger(getClass)
-
-  def createPdf(input: InputStream, output: OutputStream): ProcessBuilder = {
-    log.debug("create pdf")
-
-    pdfRunScript.getAbsolutePath #< input #> output
+    DatasetValidator.validate(depositor) shouldBe expected
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/LdapSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/LdapSpec.scala
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import javax.naming.NamingEnumeration
 import javax.naming.directory.{Attributes, SearchControls, SearchResult}
 import javax.naming.ldap.LdapContext
 
+import nl.knaw.dans.easy.license.UnitSpec
 import org.scalamock.scalatest.MockFactory
 import rx.lang.scala.observers.TestSubscriber
 
@@ -48,7 +49,7 @@ class LdapSpec extends UnitSpec with MockFactory {
       result.next _ expects () returns new SearchResult("foobar2", null, attrs2)
     }
 
-    val ldap = new LdapImpl(ctx)
+    val ldap = LdapImpl(ctx)
     val testSubscriber = TestSubscriber[Attributes]
     ldap.query(testDepositorID)(identity).subscribe(testSubscriber)
 
@@ -70,7 +71,7 @@ class LdapSpec extends UnitSpec with MockFactory {
 
     result.hasMore _ expects () returns false once()
 
-    val ldap = new LdapImpl(ctx)
+    val ldap = LdapImpl(ctx)
     val testSubscriber = TestSubscriber[Attributes]
     ldap.query(testDepositorID)(identity).subscribe(testSubscriber)
 

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/LdapSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/LdapSpec.scala
@@ -51,7 +51,7 @@ class LdapSpec extends UnitSpec with MockFactory {
 
     val ldap = LdapImpl(ctx)
     val testSubscriber = TestSubscriber[Attributes]
-    ldap.query(testDepositorID)(identity).subscribe(testSubscriber)
+    ldap.query(testDepositorID).subscribe(testSubscriber)
 
     testSubscriber.awaitTerminalEvent()
     testSubscriber.assertValues(attrs1, attrs2)
@@ -73,7 +73,7 @@ class LdapSpec extends UnitSpec with MockFactory {
 
     val ldap = LdapImpl(ctx)
     val testSubscriber = TestSubscriber[Attributes]
-    ldap.query(testDepositorID)(identity).subscribe(testSubscriber)
+    ldap.query(testDepositorID).subscribe(testSubscriber)
 
     testSubscriber.awaitTerminalEvent()
     testSubscriber.assertNoValues()

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
@@ -19,7 +19,7 @@ import java.io.File
 import java.{util => ju}
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory
-import nl.knaw.dans.easy.license.{Parameters, UnitSpec}
+import nl.knaw.dans.easy.license.UnitSpec
 import nl.knaw.dans.pf.language.emd.Term.{Name, Namespace}
 import nl.knaw.dans.pf.language.emd._
 import nl.knaw.dans.pf.language.emd.types.{IsoDate, MetadataItem}

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
@@ -19,7 +19,7 @@ import java.io.File
 import java.{util => ju}
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory
-import nl.knaw.dans.easy.license.UnitSpec
+import nl.knaw.dans.easy.license.{FileAccessRight, FileItem, UnitSpec}
 import nl.knaw.dans.pf.language.emd.Term.{Name, Namespace}
 import nl.knaw.dans.pf.language.emd._
 import nl.knaw.dans.pf.language.emd.types.{IsoDate, MetadataItem}

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import java.io.File
 import java.{util => ju}
 
 import nl.knaw.dans.common.lang.dataset.AccessCategory
+import nl.knaw.dans.easy.license.{Parameters, UnitSpec}
 import nl.knaw.dans.pf.language.emd.Term.{Name, Namespace}
 import nl.knaw.dans.pf.language.emd._
 import nl.knaw.dans.pf.language.emd.types.{IsoDate, MetadataItem}

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
@@ -44,7 +44,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   val rights = mock[EmdRights]
   val fedora = mock[Fedora]
 
-  implicit val parameters = new Parameters(new File(testDir, "placeholdermapper"), null, false, fedora, null)
+  implicit val parameters = Parameters(new File(testDir, "placeholdermapper"), null, false, fedora, null)
 
   before {
     new File(getClass.getResource("/placeholdermapper/").toURI).copyDir(parameters.templateResourceDir)
@@ -107,7 +107,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   }
 
   "sampleHeader" should "yield a map of the date and title" in {
-    implicit val parameters = new Parameters(new File(testDir, "placeholdermapper"), null, true, fedora, null)
+    implicit val parameters = Parameters(new File(testDir, "placeholdermapper"), null, true, fedora, null)
     val dates = ju.Arrays.asList(new IsoDate("1992-07-30"), new IsoDate("2016-07-30"))
 
     emd.getEmdIdentifier _ expects () never()
@@ -126,7 +126,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   }
 
   it should "yield a map with default values if the actual values are null" in {
-    implicit val parameters = new Parameters(new File(testDir, "placeholdermapper"), null, true, fedora, null)
+    implicit val parameters = Parameters(new File(testDir, "placeholdermapper"), null, true, fedora, null)
 
     emd.getEmdIdentifier _ expects () never()
     ident.getDansManagedDoi _ expects () never()
@@ -173,7 +173,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   }
 
   "depositor" should "yield a map with depositor data" in {
-    val depositor = new EasyUser("name", "org", "addr", "postal", "city", "country", "tel", "mail")
+    val depositor = EasyUser("name", "org", "addr", "postal", "city", "country", "tel", "mail")
 
     val res = testInstance.depositor(depositor)
 

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/VelocityTemplateResolverSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/VelocityTemplateResolverSpec.scala
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy.license.internal
 import java.io.{ByteArrayOutputStream, File}
 import java.util.Properties
 
-import nl.knaw.dans.easy.license.{BaseParameters, UnitSpec}
+import nl.knaw.dans.easy.license.UnitSpec
 import org.apache.velocity.exception.MethodInvocationException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/VelocityTemplateResolverSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/VelocityTemplateResolverSpec.scala
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package nl.knaw.dans.easy.license
+package nl.knaw.dans.easy.license.internal
 
 import java.io.{ByteArrayOutputStream, File}
 import java.util.Properties
 
+import nl.knaw.dans.easy.license.{BaseParameters, UnitSpec}
 import org.apache.velocity.exception.MethodInvocationException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}


### PR DESCRIPTION
~~fixes EASY-~~

Based on some feedback by @ekoi I decided to move the internal API stuff into a separate package called `internal`, signalling that the user is **NOT** supposed to use this part of the code base.

#### When applied it will
* move the internal objects to a separate package `internal`
* move the command line specific classes to a separate package `app`

Changes to dependant projects will be done in separate PRs that will appear soon.

#### Where should the reviewer @DANS-KNAW/easy start?
Check out these changes in the IDE(A). See if it all makes sense and whether I missed some things

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR | Comments
-------------------------- | ----------------- | ------
easy-app                      | [PR#19](https://github.com/DANS-KNAW/easy-app/pull/19) |
easy-app | [PR#2](https://github.com/jo-pol/easy-app/pull/2) | amendment on the PR by @jo-pol 
easy-ingest-flow | [PR#49](https://github.com/DANS-KNAW/easy-ingest-flow/pull/49) |
