### PR TITLE
better error handling and main class declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 	<description>Create license file for EASY deposits</description>
     <inceptionYear>2016</inceptionYear>
 	<properties>
-		<main-class>nl.knaw.dans.easy.license.Command</main-class>
+		<main-class>nl.knaw.dans.easy.license.app.Command</main-class>
 	</properties>
 	<scm>
 		<developerConnection>scm:git:https://github.com/DANS-KNAW/easy-license-creator</developerConnection>

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
@@ -171,6 +171,11 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
         .combineLatestWith(emd.map(_.getEmdAudience).flatMap(getAudiences).toSeq)(_(_))
         .combineLatestWith(getFilesInDataset(datasetID).toSeq)(_(_))
         .single
+        .onErrorResumeNext {
+          case e: IllegalArgumentException => Observable.error(MultipleDatasetsFoundException(datasetID))
+          case e: NoSuchElementException => Observable.error(NoDatasetFoundException(datasetID))
+          case e => Observable.error(e)
+        }
     })
   }
 
@@ -228,6 +233,11 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
         EasyUser(name, org, addr, code, place, country, phone, mail)
       })
       .single
+      .onErrorResumeNext {
+        case e: IllegalArgumentException => Observable.error(MultipleUsersFoundException(depositorID))
+        case e: NoSuchElementException => Observable.error(NoUserFoundException(depositorID))
+        case e => Observable.error(e)
+      }
   }
 }
 

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -71,6 +71,11 @@ package object internal {
     new File(parameters.templateResourceDir, "/pdfgen.sh")
   }
 
+  case class MultipleDatasetsFoundException(datasetID: DatasetID) extends Exception(s"Found more than one dataset with id: '$datasetID'")
+  case class NoDatasetFoundException(datasetID: DatasetID) extends Exception(s"Could not find dataset with id: '$datasetID")
+  case class MultipleUsersFoundException(depositorID: DepositorID) extends Exception(s"Found more than one depositor with id: '$depositorID'")
+  case class NoUserFoundException(depositorID: DepositorID) extends Exception(s"Could not find depositor with id: '$depositorID'")
+
   object Version {
     def apply(): String = {
       val props = new Properties()

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
@@ -99,7 +99,7 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
     loader.getUserById("testID").subscribe(testObserver)
 
     testObserver.assertNoValues()
-    testObserver.assertError(classOf[NoSuchElementException])
+    testObserver.assertError(classOf[NoUserFoundException])
     testObserver.assertNotCompleted()
   }
 
@@ -111,7 +111,7 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
     loader.getUserById("testID").subscribe(testObserver)
 
     testObserver.assertNoValues()
-    testObserver.assertError(classOf[IllegalArgumentException])
+    testObserver.assertError(classOf[MultipleUsersFoundException])
     testObserver.assertNotCompleted()
   }
 


### PR DESCRIPTION
~~fixes EASY-~~

I came across this bug while working on EASY-1115. I had not created clear error messages when the dataset or user is either not found or found multiple times. With this PR it should give the user a better clue of what is going wrong!

Also, this changes the `main-class` property in the `pom.xml`. The main class was moved a long time ago, but for some reason (#BlameIntelliJ) this property was not updated with it.

#### Where should the reviewer @DANS-KNAW/easy start?
* Better exception messages are provided in `DatasetLoader.scala`
* `main-class` property change in `pom.xml`

#### How should this be manually tested?
* install (`mvnci`) and deploy on deasy
* change the `depositorId` in the AMD of an existing dataset in Fedora
* on deasy, run the command `easy-license-creator <id-of-dataset-you-just-changed> <location-of-the-pdf`
* this should result in an exception printed on the screen, saying `Could not find depositor with id: '<unknown depositor id>`