### PR TITLE
Parent upgrade and remove hardcoded Scallop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>nl.knaw.dans.shared</groupId>
 		<artifactId>dans-scala-prototype</artifactId>
-		<version>1.32</version>
+		<version>1.34</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.knaw.dans.easy</groupId>
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
-			<version>2.0.2</version>
         </dependency>
 		<dependency>
 			<groupId>commons-configuration</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>nl.knaw.dans.shared</groupId>
 		<artifactId>dans-scala-prototype</artifactId>
-		<version>1.34</version>
+		<version>1.35</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.knaw.dans.easy</groupId>


### PR DESCRIPTION
fixes [EASY-1049](https://drivenbydata.atlassian.net/browse/EASY-1049)

#### When applied it will
* upgrade the project's parent project to version 1.35
* remove the hardcoded Scallop version 

#### Where should the reviewer @DANS-KNAW/easy start?
`pom.xml`