### PR TITLE
remove ajp, upgrade Jetty to 9.x

### DIFF
--- a/debug-reset-apphome.sh
+++ b/debug-reset-apphome.sh
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -17,112 +17,142 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>nl.knaw.dans.shared</groupId>
 		<artifactId>dans-scala-prototype</artifactId>
-		<version>1.39</version>
+		<version>1.47</version>
 	</parent>
-	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>nl.knaw.dans.easy</groupId>
 	<artifactId>easy-license-creator</artifactId>
 	<version>1.x-SNAPSHOT</version>
+
 	<name>EASY License Creator</name>
 	<url>https://github.com/DANS-KNAW/easy-license-creator</url>
 	<description>Create license file for EASY deposits</description>
-    <inceptionYear>2016</inceptionYear>
+	<inceptionYear>2016</inceptionYear>
+
 	<properties>
 		<main-class>nl.knaw.dans.easy.license.app.Command</main-class>
 	</properties>
+
 	<scm>
 		<developerConnection>scm:git:https://github.com/DANS-KNAW/easy-license-creator</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
+
 	<dependencies>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.scala-lang.modules</groupId>
-			<artifactId>scala-xml_2.11</artifactId>
-		</dependency>
+		<!-- testing -->
 		<dependency>
 			<groupId>org.scalatest</groupId>
 			<artifactId>scalatest_2.11</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>org.scalamock</groupId>
-            <artifactId>scalamock-scalatest-support_2.11</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
-        </dependency>
 		<dependency>
-			<groupId>commons-configuration</groupId>
-			<artifactId>commons-configuration</artifactId>
+			<groupId>org.scalamock</groupId>
+			<artifactId>scalamock-scalatest-support_2.11</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
+			<groupId>org.scalatra</groupId>
+			<artifactId>scalatra-scalatest_2.11</artifactId>
+			<version>2.5.0</version>
+			<scope>test</scope>
 		</dependency>
+
+		<!-- Scala utils -->
 		<dependency>
-			<groupId>nl.knaw.dans.easy</groupId>
-			<artifactId>emd</artifactId>
-			<version>3.0</version>
-		</dependency>
-        <!-- Avoid warnings in build log -->
-        <dependency>
-            <groupId>org.joda</groupId>
-            <artifactId>joda-convert</artifactId>
-        </dependency>
-		<dependency>
-			<groupId>io.reactivex</groupId>
-			<artifactId>rxscala_2.11</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.yourmediashelf.fedora.client</groupId>
-			<artifactId>fedora-client-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.velocity</groupId>
-			<artifactId>velocity</artifactId>
-			<version>1.7</version>
+			<groupId>org.scala-lang.modules</groupId>
+			<artifactId>scala-xml_2.11</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.jsuereth</groupId>
 			<artifactId>scala-arm_2.11</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.rogach</groupId>
+			<artifactId>scallop_2.11</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>nl.knaw.dans.lib</groupId>
 			<artifactId>dans-scala-lib</artifactId>
+			<version>1.2</version>
 		</dependency>
+
+		<!-- EASY -->
+		<dependency>
+			<groupId>nl.knaw.dans.easy</groupId>
+			<artifactId>emd</artifactId>
+			<version>3.0</version>
+		</dependency>
+
+		<!-- Apache -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-configuration</groupId>
+			<artifactId>commons-configuration</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-daemon</groupId>
+			<artifactId>commons-daemon</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.velocity</groupId>
+			<artifactId>velocity</artifactId>
+			<version>1.7</version>
+		</dependency>
+
+		<!-- service -->
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
+			<version>9.4.6.v20170531</version>
 		</dependency>
-        <dependency>
-            <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-scalate_2.11</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-daemon</groupId>
-            <artifactId>commons-daemon</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+			<version>9.4.6.v20170531</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scalatra</groupId>
+			<artifactId>scalatra_2.11</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+		</dependency>
+
+		<!-- logging -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.7</version>
+		</dependency>
+
+		<!-- joda -->
+		<!-- this dependency is here only to avoid warnings in build log -->
+		<dependency>
+			<groupId>org.joda</groupId>
+			<artifactId>joda-convert</artifactId>
+		</dependency>
+
+		<!-- reactive programming -->
+		<dependency>
+			<groupId>io.reactivex</groupId>
+			<artifactId>rxscala_2.11</artifactId>
+		</dependency>
+
+		<!-- fedora -->
+		<dependency>
+			<groupId>com.yourmediashelf.fedora.client</groupId>
+			<artifactId>fedora-client-core</artifactId>
+		</dependency>
 	</dependencies>
+
 	<repositories>
 		<repository>
 			<id>DANS</id>
@@ -132,6 +162,7 @@
 			<url>http://maven.dans.knaw.nl/</url>
 		</repository>
 	</repositories>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -157,6 +188,7 @@
             </plugin>
 		</plugins>
 	</build>
+
     <profiles>
         <profile>
             <id>command</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,7 @@
 		<dependency>
 			<groupId>nl.knaw.dans.easy</groupId>
 			<artifactId>emd</artifactId>
-			<version>3.0
-</version>
+			<version>3.0</version>
 		</dependency>
         <!-- Avoid warnings in build log -->
         <dependency>
@@ -114,10 +113,6 @@
         <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-scalate_2.11</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-ajp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/run-service.sh
+++ b/run-service.sh
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -7,7 +7,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/FileItem.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/FileItem.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/LicenseCreator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/LicenseCreator.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/Parameters.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/app/ApplicationSettings.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/ApplicationSettings.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/Command.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/CommandLineOptions.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/app/LicenseCreatorService.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/LicenseCreatorService.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/app/LicenseCreatorService.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/LicenseCreatorService.scala
@@ -23,7 +23,6 @@ import com.yourmediashelf.fedora.client.{FedoraClient, FedoraCredentials}
 import nl.knaw.dans.easy.license.LicenseCreator
 import nl.knaw.dans.easy.license.internal.{Parameters, _}
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.eclipse.jetty.ajp.Ajp13SocketConnector
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.scalatra.servlet.ScalatraListener
@@ -41,14 +40,6 @@ class LicenseCreatorService extends ApplicationSettings with DebugEnhancedLoggin
 
   server.setHandler(context)
   logger.info(s"HTTP port is $port")
-
-  if (props.containsKey("daemon.ajp.port")) {
-    val ajp = new Ajp13SocketConnector()
-    val ajpPort = props.getInt("daemon.ajp.port")
-    ajp.setPort(ajpPort)
-    server.addConnector(ajp)
-    logger.info(s"AJP port is $ajpPort")
-  }
 
   def start(): Try[Unit] = Try {
     logger.info("Starting HTTP service ...")

--- a/src/main/scala/nl/knaw/dans/easy/license/app/ServiceStarter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/app/ServiceStarter.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetLoader.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetValidator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/DatasetValidator.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Fedora.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Fedora.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/KeywordMapping.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/KeywordMapping.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Ldap.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/Parameters.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/PdfGenerator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/PdfGenerator.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapper.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/TemplateResolver.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/internal/package.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/easy/license/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/license/package.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/easy/license/UnitSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/UnitSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetLoaderSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetValidatorSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/DatasetValidatorSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/LdapSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/LdapSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/PlaceholderMapperSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/easy/license/internal/VelocityTemplateResolverSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/internal/VelocityTemplateResolverSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
~~fixes EASY-~~

#### When applied it will
* remove AJP support
* upgrade to Jetty 9.x
* upgrade to parent 1.47 (+ license headers)
* order `pom.xml` by (a.o.) categorizing the dependencies such that they can be found easier

@DANS-KNAW/easy for review