### PR TITLE
EASY-1339: prettyprinting the polygon

### DIFF
--- a/src/test/resources/debug-config/logback-service.xml
+++ b/src/test/resources/debug-config/logback-service.xml
@@ -2,7 +2,7 @@
 <configuration scan="true" scanPeriod="1 minute">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%-5level] %logger{15} - %msg %n</pattern>
+            <pattern>[%date{ISO8601}] %-5level %msg %n</pattern>
         </encoder>
     </appender>
 

--- a/src/test/resources/debug-config/logback.xml
+++ b/src/test/resources/debug-config/logback.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-		<encoder>
-			<pattern>[%-5level] %logger{15} - %msg %n</pattern>
-		</encoder>
-	</appender>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date{ISO8601}] %-5level %msg %n</pattern>
+        </encoder>
+    </appender>
 
-	<appender name="FILE"
-		class="ch.qos.logback.core.FileAppender">
-		<file>data/easy-license-creator.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<fileNamePattern>data/easy-license-creator.%d{yyyy-MM-dd}.log</fileNamePattern>
-			<maxHistory>30</maxHistory>
-		</rollingPolicy>
-		<encoder>
-			<pattern>[%thread] %-5level %logger{10} - %msg%n</pattern>
-		</encoder>
-	</appender>
-	<root level="error">
-		<appender-ref ref="FILE" />
-		<appender-ref ref="STDOUT" />
-	</root>
-	<logger name="nl.knaw.dans.easy" level="trace" />
+    <appender name="FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>data/easy-license-creator.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>data/easy-license-creator.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%date{ISO8601}] %-5level %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="error">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="nl.knaw.dans.easy" level="trace"/>
 </configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level %msg%n</pattern>
+        </encoder>
+    </appender>
 
     <!-- No logging during the build -->
-	<root level="off" />
+    <root level="off">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}"/>
+    <logger name="org.scalatest" level="info"/>
 
 </configuration>

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
@@ -45,7 +45,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   private val rights = mock[EmdRights]
   private val fedora = mock[Fedora]
 
-  implicit val parameters = Parameters(
+  implicit val parameters: Parameters = Parameters(
     templateResourceDir = new File(testDir, "placeholdermapper"),
     datasetID = null,
     isSample = false,
@@ -115,7 +115,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   }
 
   "sampleHeader" should "yield a map of the date and title" in {
-    implicit val parameters = Parameters(
+    implicit val parameters: Parameters = Parameters(
       templateResourceDir = new File(testDir, "placeholdermapper"),
       datasetID = null,
       isSample = true,
@@ -140,7 +140,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   }
 
   it should "yield a map with default values if the actual values are null" in {
-    implicit val parameters = Parameters(
+    implicit val parameters: Parameters = Parameters(
       templateResourceDir = new File(testDir, "placeholdermapper"),
       datasetID = null,
       isSample = true,
@@ -418,7 +418,7 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
     emd.getTerm _ expects abstractTerm returning abstractItems
 
     testInstance.metadataTable(emd, Seq("abc", "def"), "datasetID:1234").asScala should contain allOf (
-      Map(MetadataKey.keyword -> "ghi", MetadataValue.keyword -> "item4, item5, item6").asJava,
+      Map(MetadataKey.keyword -> "ghi", MetadataValue.keyword -> "item4<br/>item5<br/>item6").asJava,
       Map(MetadataKey.keyword -> "def", MetadataValue.keyword -> "Anonymous").asJava,
       Map(MetadataKey.keyword -> "abc", MetadataValue.keyword -> "abc; def").asJava
     )


### PR DESCRIPTION
fixes EASY-1339

#### When applied it will
* [x] do a proper pretty printing of the polygon
* ~~verify with Hella/Heiko when the CC0 attachment needs to be added~~ (coming in next PR)
* ~~adjust the texts in the license according to the connection of OPEN_ACCESS and CC0~~ (coming in next PR)
* fix a logback error
* do an accidental formatting

@DANS-KNAW/easy for review

[Here is an example of the new pdf. For the changes, check out page 5/6.](https://github.com/DANS-KNAW/easy-license-creator/files/1323817/easy-dataset.13.pdf)
