### PR TITLE
EASY-1358: limit number of files listed in the license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
             <groupId>com.yourmediashelf.fedora.client</groupId>
             <artifactId>fedora-client-core</artifactId>
         </dependency>
+
+        <!-- databases -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -7,6 +7,6 @@ fsrdb.db-connection-password=changeme
 auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=changeme
-license.resources=/var/opt/dans.knaw.nl/resource/easy-license-creator/
+license.resources=/var/opt/dans.knaw.nl/resource/easy-license-creator
 license.fileLimit=1000
 daemon.http.port=20130

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -8,4 +8,5 @@ auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=changeme
 license.resources=/var/opt/dans.knaw.nl/resource/easy-license-creator/
+license.fileLimit=1000
 daemon.http.port=20130

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,6 +1,9 @@
 fcrepo.url=http://localhost:8080/fedora
 fcrepo.user=fedoraAdmin
 fcrepo.password=changeme
+fsrdb.db-connection-url=jdbc:postgresql://localhost:5432/easy_db
+fsrdb.db-connection-username=easy_webui
+fsrdb.db-connection-password=changeme
 auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=changeme

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -8,5 +8,5 @@ auth.ldap.url=ldap://localhost
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=changeme
 license.resources=/var/opt/dans.knaw.nl/resource/easy-license-creator
-license.fileLimit=1000
+license.fileLimit=500
 daemon.http.port=20130

--- a/src/main/assembly/dist/res/template/FileTable.html
+++ b/src/main/assembly/dist/res/template/FileTable.html
@@ -13,3 +13,7 @@
     </tr>
     #end
 </table>
+
+<p>Please not that only the first $limitFiles are listed here in order to keep this license at a
+    reasonable size. For the full list of files, please contant DANS at
+    <a href="mailto:info@dans.knaw.nl">info@dans.knaw.nl</a>.</p>

--- a/src/main/assembly/dist/res/template/FileTable.html
+++ b/src/main/assembly/dist/res/template/FileTable.html
@@ -15,7 +15,7 @@
 </table>
 
 #if ($shouldLimitFiles)
-<p>Please not that only the first $limitFiles files are listed here in order to keep this license at
+<p>Please note that only the first $limitFiles files are listed here in order to keep this license at
     a reasonable size. For the full list of files, please contant DANS at
     <a href="mailto:info@dans.knaw.nl">info@dans.knaw.nl</a>.</p>
 #end

--- a/src/main/assembly/dist/res/template/FileTable.html
+++ b/src/main/assembly/dist/res/template/FileTable.html
@@ -14,6 +14,8 @@
     #end
 </table>
 
-<p>Please not that only the first $limitFiles are listed here in order to keep this license at a
-    reasonable size. For the full list of files, please contant DANS at
+#if ($shouldLimitFiles)
+<p>Please not that only the first $limitFiles files are listed here in order to keep this license at
+    a reasonable size. For the full list of files, please contant DANS at
     <a href="mailto:info@dans.knaw.nl">info@dans.knaw.nl</a>.</p>
+#end

--- a/src/main/scala/nl.knaw.dans.easy.license/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Command.scala
@@ -53,7 +53,8 @@ object Command extends App with DebugEnhancedLogging {
           datasetID = commandLine.datasetID(),
           isSample = commandLine.isSample(),
           fedoraClient = app.fedoraClient,
-          ldapContext = app.ldapContext)
+          ldapContext = app.ldapContext,
+          fsrdb = app.fsrbd)
         val outputFile = commandLine.outputFile()
 
         logger.debug(s"Using the following settings: $params")

--- a/src/main/scala/nl.knaw.dans.easy.license/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Command.scala
@@ -54,7 +54,8 @@ object Command extends App with DebugEnhancedLogging {
           isSample = commandLine.isSample(),
           fedoraClient = app.fedoraClient,
           ldapContext = app.ldapContext,
-          fsrdb = app.fsrbd)
+          fsrdb = app.fsrbd,
+          fileLimit = app.fileLimit)
         val outputFile = commandLine.outputFile()
 
         logger.debug(s"Using the following settings: $params")

--- a/src/main/scala/nl.knaw.dans.easy.license/FileItem.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/FileItem.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.license
 
 import nl.knaw.dans.easy.license.FileAccessRight.FileAccessRight
 
-case class FileItem(path: String, accessibleTo: FileAccessRight, checkSum: String)
+case class FileItem(path: String, accessibleTo: FileAccessRight, checkSum: Option[String])
 
 // TODO replace this object with a 'commons-library-call' (see also EASY-Stage-FileItem)
 object FileAccessRight extends Enumeration {

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreator.scala
@@ -63,7 +63,7 @@ class LicenseCreatorWithDatasetLoader(datasetLoader: DatasetLoader,
   // used in Easy-Ingest-Flow
   def createLicense(emd: EasyMetadata, depositorID: DepositorID, files: Seq[FileItem])
                    (outputStream: OutputStream): Observable[Nothing] = {
-    datasetLoader.getDataset(parameters.datasetID, emd, depositorID, files)
+    datasetLoader.getDataset(parameters.datasetID, emd, depositorID, files, parameters.fileLimit)
       .flatMap(createLicense(_)(outputStream).toObservable)
       .filter(_ => false)
       .asInstanceOf[Observable[Nothing]]

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
@@ -28,6 +28,10 @@ class LicenseCreatorApp(configuration: Configuration) extends AutoCloseable {
     configuration.properties.getString("fcrepo.url"),
     configuration.properties.getString("fcrepo.user"),
     configuration.properties.getString("fcrepo.password")))
+  val fsrbd: (String, String, String) = (
+    configuration.properties.getString("fsrdb.db-connection-url"),
+    configuration.properties.getString("fsrdb.db-connection-username"),
+    configuration.properties.getString("fsrdb.db-connection-password"))
   val ldapContext: InitialLdapContext = {
     import java.{ util => ju }
 

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
@@ -32,6 +32,7 @@ class LicenseCreatorApp(configuration: Configuration) extends AutoCloseable {
     configuration.properties.getString("fsrdb.db-connection-url"),
     configuration.properties.getString("fsrdb.db-connection-username"),
     configuration.properties.getString("fsrdb.db-connection-password"))
+  val fileLimit: Int = configuration.properties.getInt("license.fileLimit")
   val ldapContext: InitialLdapContext = {
     import java.{ util => ju }
 

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.license
 
 import java.io.ByteArrayOutputStream
 
-import nl.knaw.dans.easy.license.internal.{ Parameters => Params, _ }
+import nl.knaw.dans.easy.license.internal.{ Parameters => Params }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra._
 
@@ -34,7 +34,8 @@ class LicenseCreatorServlet(app: LicenseCreatorApp) extends ScalatraServlet with
       datasetID = params("datasetId"),
       isSample = false,
       fedoraClient = app.fedoraClient,
-      ldapContext = app.ldapContext)
+      ldapContext = app.ldapContext,
+      fsrdb = app.fsrbd)
 
     var success = false // TODO: get rid of var
     val output = new ByteArrayOutputStream()

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
@@ -35,7 +35,8 @@ class LicenseCreatorServlet(app: LicenseCreatorApp) extends ScalatraServlet with
       isSample = false,
       fedoraClient = app.fedoraClient,
       ldapContext = app.ldapContext,
-      fsrdb = app.fsrbd)
+      fsrdb = app.fsrbd,
+      fileLimit = app.fileLimit)
 
     var success = false // TODO: get rid of var
     val output = new ByteArrayOutputStream()

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
@@ -32,7 +32,7 @@ class LicenseCreatorServlet(app: LicenseCreatorApp) extends ScalatraServlet with
     val parameters = new Params(
       templateResourceDir = app.templateResourceDir,
       datasetID = params("datasetId"),
-      isSample = false,
+      isSample = params.get("sample").fold(false)(_.toBoolean),
       fedoraClient = app.fedoraClient,
       ldapContext = app.ldapContext,
       fsrdb = app.fsrbd,

--- a/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
@@ -23,8 +23,8 @@ import nl.knaw.dans.easy.license.internal.{BaseParameters => InternalBaseParams,
 
 object BaseParameters {
 
-  def apply(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean): InternalBaseParams = {
-    new internal.BaseParameters(templateResourceDir, datasetID, isSample)
+  def apply(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fileLimit: Int): InternalBaseParams = {
+    new internal.BaseParameters(templateResourceDir, datasetID, isSample, fileLimit)
   }
 }
 
@@ -33,10 +33,10 @@ object Parameters {
   def apply(templateResourceDir: File,
             datasetID: DatasetID,
             isSample: Boolean,
+            fileLimit: Int,
             fedoraClient: FedoraClient,
             ldapContext: LdapContext,
-            fsrdb: (String, String, String),
-            fileLimit: Int): InternalParams = {
-    new internal.Parameters(templateResourceDir, datasetID, isSample, fedoraClient, ldapContext, fsrdb, fileLimit)
+            fsrdb: (String, String, String)): InternalParams = {
+    new internal.Parameters(templateResourceDir, datasetID, isSample, fileLimit, fedoraClient, ldapContext, fsrdb)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
@@ -35,7 +35,8 @@ object Parameters {
             isSample: Boolean,
             fedoraClient: FedoraClient,
             ldapContext: LdapContext,
-            fsrdb: (String, String, String)): InternalParams = {
-    new internal.Parameters(templateResourceDir, datasetID, isSample, fedoraClient, ldapContext, fsrdb)
+            fsrdb: (String, String, String),
+            fileLimit: Int): InternalParams = {
+    new internal.Parameters(templateResourceDir, datasetID, isSample, fedoraClient, ldapContext, fsrdb, fileLimit)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
@@ -34,7 +34,8 @@ object Parameters {
             datasetID: DatasetID,
             isSample: Boolean,
             fedoraClient: FedoraClient,
-            ldapContext: LdapContext): InternalParams = {
-    new internal.Parameters(templateResourceDir, datasetID, isSample, fedoraClient, ldapContext)
+            ldapContext: LdapContext,
+            fsrdb: (String, String, String)): InternalParams = {
+    new internal.Parameters(templateResourceDir, datasetID, isSample, fedoraClient, ldapContext, fsrdb)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetLoader.scala
@@ -195,8 +195,7 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
               val accessibleTo = FileAccessRight.valueOf(resultSet.getString("accessible_to"))
                 .getOrElse(throw new IllegalArgumentException(s"illegal value for accessibleTo in file: $pid"))
 
-              // TODO make checksum optional
-              FileItem(path, accessibleTo, if (sha1checksum == "null") null else sha1checksum)
+              FileItem(path, accessibleTo, if (sha1checksum == "null") None else Some(sha1checksum))
             }),
           _.close(),
           disposeEagerly = true

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetLoader.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.license.internal
 
+import java.sql.SQLException
 import javax.naming.directory.Attributes
 
 import nl.knaw.dans.easy.license.{ DatasetID, DepositorID, FileAccessRight, FileItem }
@@ -59,7 +60,8 @@ case class Dataset(datasetID: DatasetID,
                    emd: EasyMetadata,
                    easyUser: EasyUser,
                    audiences: Seq[AudienceTitle],
-                   fileItems: Seq[FileItem]) {
+                   fileItems: Seq[FileItem],
+                   filesLimited: Boolean) {
 
   require(datasetID != null, "'datasetID' must be defined")
 
@@ -94,22 +96,6 @@ trait DatasetLoader {
   def getDatasetById(datasetID: DatasetID): Observable[Dataset]
 
   /**
-    * Create a `Dataset` based on the given `datasetID`, `emd` and `easyUser`, while querying for
-    * the audience titles and the files belonging to the dataset.
-    *
-    * @param datasetID the identifier of the dataset
-    * @param emd the `EasyMetadata` of the dataset
-    * @param easyUser the depositor of the dataset
-    * @return the dataset corresponding to `datasetID`
-    */
-  def getDataset(datasetID: DatasetID, emd: EasyMetadata, easyUser: EasyUser): Observable[Dataset] = {
-    val audiences = getAudiences(emd.getEmdAudience).toSeq
-    val files = getFilesInDataset(datasetID).toSeq
-
-    audiences.combineLatestWith(files)(Dataset(datasetID, emd, easyUser, _, _))
-  }
-
-  /**
     * Create a `Dataset` based on the given `datasetID`, `emd`, `depositorID` and `files`, while
     * querying for the audience titles and the depositor data.
     *
@@ -119,11 +105,15 @@ trait DatasetLoader {
     * @param files the files belonging to the dataset
     * @return the dataset corresponding to `datasetID`
     */
-  def getDataset(datasetID: DatasetID, emd: EasyMetadata, depositorID: DepositorID, files: Seq[FileItem]): Observable[Dataset] = {
+  def getDataset(datasetID: DatasetID, emd: EasyMetadata, depositorID: DepositorID, files: Seq[FileItem], fileLimit: Int): Observable[Dataset] = {
     val audiences = getAudiences(emd.getEmdAudience).toSeq
     val easyUser = getUserById(depositorID)
+    val filesWereLimited = countFiles(datasetID).map(fileLimit <)
 
-    easyUser.combineLatestWith(audiences)(Dataset(datasetID, emd, _, _, files))
+    easyUser.combineLatest(audiences)
+      .combineLatestWith(filesWereLimited) {
+        case ((user, auds), limited) => Dataset(datasetID, emd, user, auds, files, limited)
+      }
   }
 
   /**
@@ -133,6 +123,14 @@ trait DatasetLoader {
     * @return the files corresponding to the dataset with identifier `datasetID`
     */
   def getFilesInDataset(datasetID: DatasetID): Observable[FileItem]
+
+  /**
+   * Return the number of files corresponding to the dataset with identifier `datasetID`
+   *
+   * @param datasetID the identifier of the dataset
+   * @return the number of files corresponding to the dataset with identifier `datasetID`
+   */
+  def countFiles(datasetID: DatasetID): Observable[Int]
 
   /**
     * Queries the user data given a `depositorID`
@@ -163,11 +161,12 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
     // publish because emd is used in multiple places here
     emdObs.publish(emd => {
       emd.combineLatestWith(depositorObs) {
-        (emdValue, depositorValue) => (audiences: Seq[AudienceTitle]) => (files: Seq[FileItem]) =>
-          Dataset(datasetID, emdValue, depositorValue, audiences, files)
+        (emdValue, depositorValue) => (audiences: Seq[AudienceTitle]) => (files: Seq[FileItem]) => (limited: Boolean) =>
+          Dataset(datasetID, emdValue, depositorValue, audiences, files, limited)
       }
         .combineLatestWith(emd.map(_.getEmdAudience).flatMap(getAudiences).toSeq)(_(_))
         .combineLatestWith(getFilesInDataset(datasetID).toSeq)(_(_))
+        .combineLatestWith(countFiles(datasetID).map(parameters.fileLimit <))(_(_))
         .single
         .onErrorResumeNext {
           case e: IllegalArgumentException => Observable.error(MultipleDatasetsFoundException(datasetID, e))
@@ -179,16 +178,16 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
 
   def getFilesInDataset(datasetID: DatasetID): Observable[FileItem] = {
     Class.forName("org.postgresql.Driver")
-    val query = "SELECT pid, path, sha1checksum, accessible_to FROM easy_files WHERE dataset_sid = ? ORDER BY pid;"
+    val query = "SELECT pid, path, sha1checksum, accessible_to FROM easy_files WHERE dataset_sid = ? ORDER BY pid LIMIT ?;"
     Observable.using(parameters.fsrdb.prepareStatement(query))(
       prepStatement => {
         prepStatement.setString(1, datasetID)
+        prepStatement.setInt(2, parameters.fileLimit)
 
         Observable.using(prepStatement.executeQuery())(
           resultSet => Observable.defer(Observable.just(resultSet.next()))
             .repeat
             .takeWhile(b => b)
-            .take(parameters.fileLimit)
             .map(_ => {
               val pid = resultSet.getString("pid")
               val path = resultSet.getString("path")
@@ -199,6 +198,29 @@ case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends Da
               // TODO make checksum optional
               FileItem(path, accessibleTo, if (sha1checksum == "null") null else sha1checksum)
             }),
+          _.close(),
+          disposeEagerly = true
+        )
+      },
+      _.close(),
+      disposeEagerly = true
+    )
+  }
+
+  def countFiles(datasetID: DatasetID): Observable[Int] = {
+    Class.forName("org.postgresql.Driver")
+    val query = "SELECT COUNT(pid) FROM easy_files WHERE dataset_sid = ?;"
+    Observable.using(parameters.fsrdb.prepareStatement(query))(
+      prepStatement => {
+        prepStatement.setString(1, datasetID)
+
+        Observable.using(prepStatement.executeQuery())(
+          resultSet => {
+            if (resultSet.next())
+              Observable.just(resultSet.getInt("count"))
+            else
+              Observable.error(new SQLException(s"unable to count the number of files in dataset $datasetID"))
+          },
           _.close(),
           disposeEagerly = true
         )

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/KeywordMapping.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/KeywordMapping.scala
@@ -68,4 +68,5 @@ case object FileAccessibleTo             extends KeywordMapping { val keyword = 
 
 // file limit
 case object LimitFiles                   extends KeywordMapping { val keyword = "limitFiles" }
+case object ShouldLimitFiles             extends KeywordMapping { val keyword = "shouldLimitFiles" }
 // @formatter:on

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/KeywordMapping.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/KeywordMapping.scala
@@ -65,4 +65,7 @@ case object FileTable                    extends KeywordMapping { val keyword = 
 case object FilePath                     extends KeywordMapping { val keyword = "FilePath" }
 case object FileChecksum                 extends KeywordMapping { val keyword = "FileChecksum" }
 case object FileAccessibleTo             extends KeywordMapping { val keyword = "FileAccessibleTo" }
+
+// file limit
+case object LimitFiles                   extends KeywordMapping { val keyword = "limitFiles" }
 // @formatter:on

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.license.internal
 
 import java.io.File
+import java.sql.{ Connection, DriverManager }
 import javax.naming.ldap.LdapContext
 
 import com.yourmediashelf.fedora.client.FedoraClient
@@ -30,17 +31,20 @@ class BaseParameters(val templateResourceDir: File,
 trait DatabaseParameters {
   val fedora: Fedora
   val ldap: Ldap
+  val fsrdb: Connection
 }
 
 case class Parameters(override val templateResourceDir: File,
                       override val datasetID: DatasetID,
                       override val isSample: Boolean,
                       fedora: Fedora,
-                      ldap: Ldap)
+                      ldap: Ldap,
+                      fsrdb: Connection)
   extends BaseParameters(templateResourceDir, datasetID, isSample) with DatabaseParameters {
 
-  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext) =
-    this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext))
+  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext, fsrdb: (String, String, String)) = {
+    this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3))
+  }
 
   override def toString: String = super.toString
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
@@ -26,7 +26,8 @@ import nl.knaw.dans.easy.license.DatasetID
 // java business layer.
 class BaseParameters(val templateResourceDir: File,
                      val datasetID: DatasetID,
-                     val isSample: Boolean)
+                     val isSample: Boolean,
+                     val fileLimit: Int)
 
 trait DatabaseParameters {
   val fedora: Fedora
@@ -38,14 +39,14 @@ trait DatabaseParameters {
 case class Parameters(override val templateResourceDir: File,
                       override val datasetID: DatasetID,
                       override val isSample: Boolean,
+                      override val fileLimit: Int,
                       fedora: Fedora,
                       ldap: Ldap,
-                      fsrdb: Connection,
-                      fileLimit: Int)
-  extends BaseParameters(templateResourceDir, datasetID, isSample) with DatabaseParameters {
+                      fsrdb: Connection)
+  extends BaseParameters(templateResourceDir, datasetID, isSample, fileLimit) with DatabaseParameters {
 
-  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext, fsrdb: (String, String, String), fileLimit: Int) = {
-    this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3), fileLimit)
+  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fileLimit: Int, fedoraClient: FedoraClient, ldapContext: LdapContext, fsrdb: (String, String, String)) = {
+    this(templateResourceDir, datasetID, isSample, fileLimit, FedoraImpl(fedoraClient), LdapImpl(ldapContext), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3))
   }
 
   override def toString: String = super.toString

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
@@ -32,6 +32,7 @@ trait DatabaseParameters {
   val fedora: Fedora
   val ldap: Ldap
   val fsrdb: Connection
+  val fileLimit: Int
 }
 
 case class Parameters(override val templateResourceDir: File,
@@ -39,11 +40,12 @@ case class Parameters(override val templateResourceDir: File,
                       override val isSample: Boolean,
                       fedora: Fedora,
                       ldap: Ldap,
-                      fsrdb: Connection)
+                      fsrdb: Connection,
+                      fileLimit: Int)
   extends BaseParameters(templateResourceDir, datasetID, isSample) with DatabaseParameters {
 
-  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext, fsrdb: (String, String, String)) = {
-    this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3))
+  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fedoraClient: FedoraClient, ldapContext: LdapContext, fsrdb: (String, String, String), fileLimit: Int) = {
+    this(templateResourceDir, datasetID, isSample, FedoraImpl(fedoraClient), LdapImpl(ldapContext), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3), fileLimit)
   }
 
   override def toString: String = super.toString

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapper.scala
@@ -60,7 +60,8 @@ class PlaceholderMapper(metadataTermsFile: File)(implicit parameters: BaseParame
       metadata = MetadataTable -> metadataTable(emd, dataset.audiences, dataset.datasetID)
       files @ (_, table) = FileTable -> filesTable(dataset.fileItems)
       hasFiles = HasFiles -> boolean2Boolean(!table.isEmpty)
-    } yield headerMap + dansLogo + footer ++ depositorMap ++ accessRightMap ++ embargoMap + dateTime + metadata + files + hasFiles
+      limitFiles = LimitFiles -> parameters.fileLimit.toString
+    } yield headerMap + dansLogo + footer ++ depositorMap ++ accessRightMap ++ embargoMap + dateTime + metadata + files + hasFiles + limitFiles
   }
 
   def header(emd: EasyMetadata): Try[PlaceholderMap] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapper.scala
@@ -278,8 +278,7 @@ class PlaceholderMapper(metadataTermsFile: File)(implicit parameters: BaseParame
       .map { case FileItem(path, accessibleTo, checkSum) =>
         val map = Map(
           FilePath -> path,
-          FileChecksum -> (if (checkSum.isBlank || checkSum == "none") checkSumNotCalculated
-                           else checkSum),
+          FileChecksum -> checkSum.filterNot(_.isBlank).filterNot("none" ==).getOrElse(checkSumNotCalculated),
           FileAccessibleTo -> formatFileAccessRights(accessibleTo)
         )
 

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapper.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapper.scala
@@ -61,7 +61,8 @@ class PlaceholderMapper(metadataTermsFile: File)(implicit parameters: BaseParame
       files @ (_, table) = FileTable -> filesTable(dataset.fileItems)
       hasFiles = HasFiles -> boolean2Boolean(!table.isEmpty)
       limitFiles = LimitFiles -> parameters.fileLimit.toString
-    } yield headerMap + dansLogo + footer ++ depositorMap ++ accessRightMap ++ embargoMap + dateTime + metadata + files + hasFiles + limitFiles
+      shouldLimitFiles = ShouldLimitFiles -> boolean2Boolean(dataset.filesLimited)
+    } yield headerMap + dansLogo + footer ++ depositorMap ++ accessRightMap ++ embargoMap + dateTime + metadata + files + hasFiles + limitFiles + shouldLimitFiles
   }
 
   def header(emd: EasyMetadata): Try[PlaceholderMap] = Try {

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -7,8 +7,6 @@ fsrdb.db-connection-password=easy_webui
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
-
 license.resources=home/res
 license.fileLimit=3
-
 daemon.http.port=20130

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -9,5 +9,6 @@ auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin
 
 license.resources=home/res
+license.fileLimit=3
 
 daemon.http.port=20130

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,7 +1,9 @@
 fcrepo.url=http://deasy.dans.knaw.nl:8080/fedora
 fcrepo.user=fedoraAdmin
 fcrepo.password=fedoraAdmin
-
+fsrdb.db-connection-url=jdbc:postgresql://deasy.dans.knaw.nl:5432/easy_db
+fsrdb.db-connection-username=easy_webui
+fsrdb.db-connection-password=easy_webui
 auth.ldap.url=ldap://deasy.dans.knaw.nl
 auth.ldap.user=cn=ldapadmin,dc=dans,dc=knaw,dc=nl
 auth.ldap.password=ldapadmin

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/DatasetLoaderSpec.scala
@@ -57,6 +57,7 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
     override val fedora: Fedora = fedoraMock
     override val ldap: Ldap = ldapMock
     override val fsrdb: Connection = fsrdbMock
+    override val fileLimit: Int = 2
   }
 
   before {
@@ -166,8 +167,8 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
     val id = "testID"
     val pid1 = "pid1"
     val pid2 = "pid2"
-    val fi1@FileItem(path1, accTo1, chcksm1) = FileItem("path1", FileAccessRight.NONE, "chcksm1")
-    val fi2@FileItem(path2, accTo2, _) = FileItem("path2", FileAccessRight.KNOWN, null)
+    val fi1 @ FileItem(path1, accTo1, chcksm1) = FileItem("path1", FileAccessRight.NONE, "chcksm1")
+    val fi2 @ FileItem(path2, accTo2, _) = FileItem("path2", FileAccessRight.KNOWN, null)
 
     val mockedPrepStatement = mock[PreparedStatement]
     val mockedResultSet = mock[ResultSet]
@@ -186,9 +187,10 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
       (mockedResultSet.getString(_: String)) expects "path" returning path2
       (mockedResultSet.getString(_: String)) expects "sha1checksum" returning "null"
       (mockedResultSet.getString(_: String)) expects "accessible_to" returning accTo2.toString
-      mockedResultSet.next _ expects() returning false
-      mockedResultSet.close _ expects ()
-      mockedPrepStatement.close _ expects ()
+      // no more calls to the resultSet because of the cut-off limit set to 2 for this test
+      mockedResultSet.next _ expects() returning true never()
+      mockedResultSet.close _ expects()
+      mockedPrepStatement.close _ expects()
     }
 
     val loader = DatasetLoaderImpl()

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/DatasetLoaderSpec.scala
@@ -124,8 +124,8 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
     val user = EasyUser("name", "org", "addr", "pc", "city", "cntr", "phone", "mail")
     val audiences = Seq("aud1", "aud2")
     val files = Seq(
-      FileItem("path1", FileAccessRight.RESTRICTED_GROUP, "chs1"),
-      FileItem("path2", FileAccessRight.KNOWN, "chs2")
+      FileItem("path1", FileAccessRight.RESTRICTED_GROUP, Some("chs1")),
+      FileItem("path2", FileAccessRight.KNOWN, Some("chs2"))
     )
 
     val amdStream = IOUtils.toInputStream(<foo><depositorId>{depID}</depositorId></foo>.toString)
@@ -171,8 +171,8 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
     val id = "testID"
     val pid1 = "pid1"
     val pid2 = "pid2"
-    val fi1 @ FileItem(path1, accTo1, chcksm1) = FileItem("path1", FileAccessRight.NONE, "chcksm1")
-    val fi2 @ FileItem(path2, accTo2, _) = FileItem("path2", FileAccessRight.KNOWN, null)
+    val fi1 @ FileItem(path1, accTo1, Some(chcksm1)) = FileItem("path1", FileAccessRight.NONE, Some("chcksm1"))
+    val fi2 @ FileItem(path2, accTo2, _) = FileItem("path2", FileAccessRight.KNOWN, None)
 
     val mockedPrepStatement = mock[PreparedStatement]
     val mockedResultSet = mock[ResultSet]

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/DatasetLoaderSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/DatasetLoaderSpec.scala
@@ -180,7 +180,7 @@ class DatasetLoaderSpec extends UnitSpec with MockFactory with BeforeAndAfter wi
     inSequence {
       (fsrdbMock.prepareStatement(_: String)) expects * returning mockedPrepStatement
       mockedPrepStatement.setString _ expects(1, id)
-      mockedPrepStatement.setString _ expects(2, "2")
+      mockedPrepStatement.setInt _ expects(2, 2)
       mockedPrepStatement.executeQuery _ expects() returning mockedResultSet
       mockedResultSet.next _ expects() returning true
       (mockedResultSet.getString(_: String)) expects "pid" returning pid1

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
@@ -43,14 +43,14 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
   private val ident = mock[EmdIdentifier]
   private val date = mock[EmdDate]
   private val rights = mock[EmdRights]
-  private val fedora = mock[Fedora]
 
   implicit val parameters: Parameters = Parameters(
     templateResourceDir = new File(testDir, "placeholdermapper"),
     datasetID = null,
     isSample = false,
-    fedora = fedora,
-    ldap = null)
+    fedora = null,
+    ldap = null,
+    fsrdb = null)
 
   before {
     new File(getClass.getResource("/placeholdermapper/").toURI).copyDir(parameters.templateResourceDir)
@@ -119,8 +119,9 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
       templateResourceDir = new File(testDir, "placeholdermapper"),
       datasetID = null,
       isSample = true,
-      fedora = fedora,
-      ldap = null)
+      fedora = null,
+      ldap = null,
+      fsrdb = null)
     val dates = ju.Arrays.asList(new IsoDate("1992-07-30"), new IsoDate("2016-07-30"))
 
     emd.getEmdIdentifier _ expects () never()
@@ -144,8 +145,9 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
       templateResourceDir = new File(testDir, "placeholdermapper"),
       datasetID = null,
       isSample = true,
-      fedora = fedora,
-      ldap = null)
+      fedora = null,
+      ldap = null,
+      fsrdb = null)
 
     emd.getEmdIdentifier _ expects () never()
     ident.getDansManagedDoi _ expects () never()

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
@@ -499,9 +499,9 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
 
   "filesTable" should "give a mapping of files and checksums in the dataset" in {
     val input = Seq(
-      FileItem("ABC", FileAccessRight.ANONYMOUS, "123"),
-      FileItem("DEF", FileAccessRight.KNOWN, "none"),
-      FileItem("GHI", FileAccessRight.RESTRICTED_GROUP, "")
+      FileItem("ABC", FileAccessRight.ANONYMOUS, Some("123")),
+      FileItem("DEF", FileAccessRight.KNOWN, Some("none")),
+      FileItem("GHI", FileAccessRight.RESTRICTED_GROUP, Some(""))
     )
 
     testInstance.filesTable(input).asScala should contain allOf (

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/PlaceholderMapperSpec.scala
@@ -50,7 +50,8 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
     isSample = false,
     fedora = null,
     ldap = null,
-    fsrdb = null)
+    fsrdb = null,
+    fileLimit = 3)
 
   before {
     new File(getClass.getResource("/placeholdermapper/").toURI).copyDir(parameters.templateResourceDir)
@@ -121,7 +122,8 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
       isSample = true,
       fedora = null,
       ldap = null,
-      fsrdb = null)
+      fsrdb = null,
+      fileLimit = 3)
     val dates = ju.Arrays.asList(new IsoDate("1992-07-30"), new IsoDate("2016-07-30"))
 
     emd.getEmdIdentifier _ expects () never()
@@ -147,7 +149,8 @@ class PlaceholderMapperSpec extends UnitSpec with MockFactory with BeforeAndAfte
       isSample = true,
       fedora = null,
       ldap = null,
-      fsrdb = null)
+      fsrdb = null,
+      fileLimit = 3)
 
     emd.getEmdIdentifier _ expects () never()
     ident.getDansManagedDoi _ expects () never()

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/VelocityTemplateResolverSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/VelocityTemplateResolverSpec.scala
@@ -27,7 +27,7 @@ import scala.util.{Failure, Success}
 
 class VelocityTemplateResolverSpec extends UnitSpec with BeforeAndAfter with BeforeAndAfterAll {
 
-  implicit val parameters = new BaseParameters(new File(testDir, "template"), null, false)
+  implicit val parameters = new BaseParameters(new File(testDir, "template"), null, false, 3)
 
   before {
     new File(getClass.getResource("/velocity/").toURI).copyDir(parameters.templateResourceDir)


### PR DESCRIPTION
fixes EASY-1358

#### When applied it will
* get the files list from FSRDB rather than Fedora
* limit the number of files listed in the license
* add a servlet parameter to support sample versions of the pdf

@DANS-KNAW/easy for review

#### Related pull requests:
* [easy-dtap](https://github.com/DANS-KNAW/easy-dtap/pull/159)
* [easy-app](https://github.com/DANS-KNAW/easy-app/pull/100/)