### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>
@@ -48,15 +48,15 @@
         <!-- testing -->
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
-            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <artifactId>scalamock-scalatest-support_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-scalatest_2.11</artifactId>
+            <artifactId>scalatra-scalatest_2.12</artifactId>
             <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
@@ -64,19 +64,19 @@
         <!-- Scala utils -->
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-xml_2.11</artifactId>
+            <artifactId>scala-xml_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
 
         <!-- EASY -->
@@ -116,7 +116,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -141,7 +141,7 @@
         <!-- reactive programming -->
         <dependency>
             <groupId>io.reactivex</groupId>
-            <artifactId>rxscala_2.11</artifactId>
+            <artifactId>rxscala_2.12</artifactId>
         </dependency>
 
         <!-- fedora -->

--- a/src/main/scala/nl.knaw.dans.easy.license/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Command.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.license
 
 import java.io.FileOutputStream
+import java.nio.file.Paths
 
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -28,7 +29,7 @@ import scala.util.{ Failure, Success, Try }
 object Command extends App with DebugEnhancedLogging {
   type FeedBackMessage = String
 
-  val configuration = Configuration()
+  val configuration = Configuration(Paths.get(System.getProperty("app.home")))
   val commandLine: CommandLineOptions = new CommandLineOptions(args, configuration) {
     verify()
   }

--- a/src/main/scala/nl.knaw.dans.easy.license/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Configuration.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.license
 
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.commons.configuration.PropertiesConfiguration
 import resource.managed
@@ -26,8 +26,7 @@ case class Configuration(version: String, properties: PropertiesConfiguration)
 
 object Configuration {
 
-  def apply(): Configuration = {
-    val home = Paths.get(System.getProperty("app.home"))
+  def apply(home: Path): Configuration = {
     val cfgPath = Seq(
       Paths.get(s"/etc/opt/dans.knaw.nl/easy-license-creator/"),
       home.resolve("cfg"))

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreator.scala
@@ -21,6 +21,7 @@ import nl.knaw.dans.easy.license.internal._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.pf.language.emd.EasyMetadata
 import rx.lang.scala.Observable
+import rx.lang.scala.TryToObservable
 
 import scala.util.Try
 

--- a/src/main/scala/nl.knaw.dans.easy.license/ServiceStarter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/ServiceStarter.scala
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.easy.license
 
+import java.nio.file.Paths
+
+import nl.knaw.dans.lib.error.TryExtensions
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.daemon.{ Daemon, DaemonContext }
 
@@ -24,7 +27,7 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
 
   override def init(context: DaemonContext): Unit = {
     logger.info("Initializing service...")
-    val configuration = Configuration()
+    val configuration = Configuration(Paths.get(System.getProperty("app.home")))
     app = new LicenseCreatorApp(configuration)
     service = new LicenseCreatorService(configuration.properties.getInt("daemon.http.port"), app)
     logger.info("Service initialized.")

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetLoader.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetLoader.scala
@@ -141,7 +141,7 @@ trait DatasetLoader {
   def getUserById(depositorID: DepositorID): Observable[EasyUser]
 }
 
-case class DatasetLoaderImpl(implicit parameters: DatabaseParameters) extends DatasetLoader {
+case class DatasetLoaderImpl()(implicit parameters: DatabaseParameters) extends DatasetLoader {
 
   def getAudience(audienceID: AudienceID): Observable[String] = {
     parameters.fedora.getDC(audienceID)

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetValidator.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/DatasetValidator.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.license.internal
 
+import nl.knaw.dans.lib.string.StringExtensions
+
 object DatasetValidator {
 
   def validate(dataset: Dataset): Dataset = {

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/package.scala
@@ -19,15 +19,14 @@ import java.io._
 import java.nio.charset.Charset
 import java.util.Properties
 
-import org.apache.commons.io.{Charsets, FileUtils, IOUtils}
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.io.{ Charsets, FileUtils }
 import org.slf4j.Logger
-import rx.lang.scala.Notification.{OnCompleted, OnError, OnNext}
-import rx.lang.scala.{Notification, Observable}
+import rx.lang.scala.Notification.{ OnCompleted, OnError, OnNext }
+import rx.lang.scala.{ Notification, Observable }
 
 import scala.language.postfixOps
-import scala.util.{Failure, Success, Try}
-import scala.xml.{Elem, XML}
+import scala.util.Try
+import scala.xml.{ Elem, XML }
 
 package object internal {
 
@@ -136,52 +135,6 @@ package object internal {
       * @return the file contents, never ``null``
       */
     def read(encoding: Charset = Charsets.UTF_8): String = FileUtils.readFileToString(file, encoding)
-  }
-
-  implicit class TryExtensions[T](val t: Try[T]) extends AnyVal {
-    def doOnError(f: Throwable => Unit): Try[T] = {
-      t match {
-        case Failure(e) => Try { f(e); throw e }
-        case x => x
-      }
-    }
-
-    def doOnSuccess(f: T => Unit): Try[T] = {
-      t match {
-        case Success(x) => Try { f(x); x }
-        case e => e
-      }
-    }
-
-    def eventually[Ignore](effect: () => Ignore): Try[T] = {
-      t.doOnSuccess(_ => effect()).doOnError(_ => effect())
-    }
-
-    def toObservable: Observable[T] = {
-      t match {
-        case Success(x) => Observable.just(x)
-        case Failure(e) => Observable.error(e)
-      }
-    }
-  }
-
-  implicit class StringExtensions(val s: String) extends AnyVal {
-    /**
-      * Checks whether the `String` is blank
-      *
-      * @return
-      */
-    def isBlank: Boolean = StringUtils.isBlank(s)
-
-    /** Converts a `String` to an `Option[String]`. If the `String` is blank
-      * the empty `Option` is returned, otherwise the `String` is returned
-      * wrapped in an `Option`.
-      *
-      * @return an `Option` of the input string that indicates whether it is blank
-      */
-    def toOption: Option[String] = if (s.isBlank) Option.empty else Option(s)
-
-    def emptyIfBlank: String = s.toOption.getOrElse("")
   }
 
   implicit class InputStreamExtensions(val stream: InputStream) extends AnyVal {

--- a/src/main/scala/nl.knaw.dans.easy.license/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/package.scala
@@ -27,21 +27,9 @@ package object license {
   type DatasetID = String
   type DepositorID = String
 
-  // TODO copied from easy-bag-store
-  implicit class TryExtensions2[T](val t: Try[T]) extends AnyVal {
-    // TODO candidate for dans-scala-lib
-    def unsafeGetOrThrow: T = {
-      t match {
-        case Success(value) => value
-        case Failure(throwable) => throw throwable
-      }
-    }
-  }
-
   implicit class ReactiveResourceManager[T <: Closeable](val resource: T) extends AnyVal {
     def usedIn[S](observableFactory: T => Observable[S], dispose: T => Unit = _ => {}, disposeEagerly: Boolean = false): Observable[S] = {
       Observable.using(resource)(observableFactory, t => { dispose(t); IOUtils.closeQuietly(t) }, disposeEagerly)
     }
   }
-
 }

--- a/src/test/scala/nl.knaw.dans.easy.license/internal/LdapSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.license/internal/LdapSpec.scala
@@ -38,15 +38,11 @@ class LdapSpec extends UnitSpec with MockFactory {
     (ctx.search(_: String, _: String, _: SearchControls)) expects f returning result
 
     inSequence {
-      // the first hasMore call has to do with the implementation of Observable.from...
-      result.hasMore _ expects () returns true once()
-      result.hasMore _ expects () returns true twice()
-      result.hasMore _ expects () returns false once()
-    }
-
-    inSequence {
+      result.hasMore _ expects () returns true
       result.next _ expects () returns new SearchResult("foobar1", null, attrs1)
+      result.hasMore _ expects () returns true
       result.next _ expects () returns new SearchResult("foobar2", null, attrs2)
+      result.hasMore _ expects () returns false
     }
 
     val ldap = LdapImpl(ctx)


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* provide a parameter to the `Configuration` constructor
* use the `dans-scala-lib` functions

@DANS-KNAW/easy for review