### PR TITLE
EASY-1873 Upgrade to Jetty 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-service-project</artifactId>
-        <version>2.2.3</version>
+        <version>3.0.0-beta-1</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>


### PR DESCRIPTION
Fixes EASY-1873

- [ ] Set parent to v3.0.0 when fix has been tested and new parent pom released.

#### When applied it will...
* Upgrade the Jetty engine to v9

#### Where should the reviewer @DANS-KNAW/easy start?