### PR TITLE
EASY-1727 LDAP connectie wordt niet hernieuwd nadat die gesloten is

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.license/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Command.scala
@@ -54,7 +54,7 @@ object Command extends App with DebugEnhancedLogging {
           datasetID = commandLine.datasetID(),
           isSample = commandLine.isSample(),
           fedoraClient = app.fedoraClient,
-          ldapContext = app.ldapContext,
+          ldapContext = getLdapConnection(app.ldapConnectControls),
           fsrdb = app.fsrdb,
           fileLimit = app.fileLimit)
         val outputFile = commandLine.outputFile()

--- a/src/main/scala/nl.knaw.dans.easy.license/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Command.scala
@@ -54,7 +54,7 @@ object Command extends App with DebugEnhancedLogging {
           datasetID = commandLine.datasetID(),
           isSample = commandLine.isSample(),
           fedoraClient = app.fedoraClient,
-          ldapContext = getLdapConnection(app.ldapConnectControls),
+          ldapEnv = app.ldapEnv,
           fsrdb = app.fsrdb,
           fileLimit = app.fileLimit)
         val outputFile = commandLine.outputFile()
@@ -67,6 +67,7 @@ object Command extends App with DebugEnhancedLogging {
           .doOnCompleted {
             logger.info(s"license saved at ${ outputFile.getAbsolutePath }")
             params.fsrdb.close()
+            params.ldap.close()
             success = true
           }
           .toBlocking

--- a/src/main/scala/nl.knaw.dans.easy.license/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Command.scala
@@ -66,8 +66,7 @@ object Command extends App with DebugEnhancedLogging {
           .usedIn(LicenseCreator(params).createLicense)
           .doOnCompleted {
             logger.info(s"license saved at ${ outputFile.getAbsolutePath }")
-            params.fsrdb.close()
-            params.ldap.close()
+            params.close()
             success = true
           }
           .toBlocking

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
@@ -32,14 +32,12 @@ class LicenseCreatorApp(configuration: Configuration) extends AutoCloseable {
     configuration.properties.getString("fsrdb.db-connection-username"),
     configuration.properties.getString("fsrdb.db-connection-password"))
   val fileLimit: Int = configuration.properties.getInt("license.fileLimit")
-  val ldapEnv: LdapEnv = {
-    val env = new LdapEnv
-    env.put(Context.PROVIDER_URL, configuration.properties.getString("auth.ldap.url"))
-    env.put(Context.SECURITY_AUTHENTICATION, "simple")
-    env.put(Context.SECURITY_PRINCIPAL, configuration.properties.getString("auth.ldap.user"))
-    env.put(Context.SECURITY_CREDENTIALS, configuration.properties.getString("auth.ldap.password"))
-    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
-    env
+  val ldapEnv: LdapEnv = new LdapEnv {
+    put(Context.PROVIDER_URL, configuration.properties.getString("auth.ldap.url"))
+    put(Context.SECURITY_AUTHENTICATION, "simple")
+    put(Context.SECURITY_PRINCIPAL, configuration.properties.getString("auth.ldap.user"))
+    put(Context.SECURITY_CREDENTIALS, configuration.properties.getString("auth.ldap.password"))
+    put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
   }
 
   override def close(): Unit = {

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
@@ -32,10 +32,8 @@ class LicenseCreatorApp(configuration: Configuration) extends AutoCloseable {
     configuration.properties.getString("fsrdb.db-connection-username"),
     configuration.properties.getString("fsrdb.db-connection-password"))
   val fileLimit: Int = configuration.properties.getInt("license.fileLimit")
-  val ldapConnectControls: LdapConnectControls = {
-    import java.{ util => ju }
-
-    val env = new ju.Hashtable[String, String]
+  val ldapEnv: LdapEnv = {
+    val env = new LdapEnv
     env.put(Context.PROVIDER_URL, configuration.properties.getString("auth.ldap.url"))
     env.put(Context.SECURITY_AUTHENTICATION, "simple")
     env.put(Context.SECURITY_PRINCIPAL, configuration.properties.getString("auth.ldap.user"))

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorApp.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.license
 
 import java.io.File
 import javax.naming.Context
-import javax.naming.ldap.InitialLdapContext
 
 import com.yourmediashelf.fedora.client.{ FedoraClient, FedoraCredentials }
 import rx.schedulers.Schedulers
@@ -33,7 +32,7 @@ class LicenseCreatorApp(configuration: Configuration) extends AutoCloseable {
     configuration.properties.getString("fsrdb.db-connection-username"),
     configuration.properties.getString("fsrdb.db-connection-password"))
   val fileLimit: Int = configuration.properties.getInt("license.fileLimit")
-  val ldapContext: InitialLdapContext = {
+  val ldapConnectControls: LdapConnectControls = {
     import java.{ util => ju }
 
     val env = new ju.Hashtable[String, String]
@@ -42,12 +41,10 @@ class LicenseCreatorApp(configuration: Configuration) extends AutoCloseable {
     env.put(Context.SECURITY_PRINCIPAL, configuration.properties.getString("auth.ldap.user"))
     env.put(Context.SECURITY_CREDENTIALS, configuration.properties.getString("auth.ldap.password"))
     env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
-
-    new InitialLdapContext(env, null)
+    env
   }
 
   override def close(): Unit = {
-    ldapContext.close()
     Schedulers.shutdown()
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
@@ -43,8 +43,7 @@ class LicenseCreatorServlet(app: LicenseCreatorApp) extends ScalatraServlet with
     output
       .usedIn(LicenseCreator(parameters).createLicense)
       .doOnCompleted {
-        parameters.fsrdb.close()
-        parameters.ldap.close()
+        parameters.close()
         success = true
       }
       .toBlocking

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
@@ -34,7 +34,7 @@ class LicenseCreatorServlet(app: LicenseCreatorApp) extends ScalatraServlet with
       datasetID = params("datasetId"),
       isSample = params.get("sample").fold(false)(_.toBoolean),
       fedoraClient = app.fedoraClient,
-      ldapContext = getLdapConnection(app.ldapConnectControls),
+      ldapEnv = app.ldapEnv,
       fsrdb = app.fsrdb,
       fileLimit = app.fileLimit)
 
@@ -44,6 +44,7 @@ class LicenseCreatorServlet(app: LicenseCreatorApp) extends ScalatraServlet with
       .usedIn(LicenseCreator(parameters).createLicense)
       .doOnCompleted {
         parameters.fsrdb.close()
+        parameters.ldap.close()
         success = true
       }
       .toBlocking

--- a/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/LicenseCreatorServlet.scala
@@ -34,7 +34,7 @@ class LicenseCreatorServlet(app: LicenseCreatorApp) extends ScalatraServlet with
       datasetID = params("datasetId"),
       isSample = params.get("sample").fold(false)(_.toBoolean),
       fedoraClient = app.fedoraClient,
-      ldapContext = app.ldapContext,
+      ldapContext = getLdapConnection(app.ldapConnectControls),
       fsrdb = app.fsrdb,
       fileLimit = app.fileLimit)
 

--- a/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/Parameters.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.license
 
 import java.io.File
-import javax.naming.ldap.LdapContext
 
 import com.yourmediashelf.fedora.client.FedoraClient
 import nl.knaw.dans.easy.license.internal.{BaseParameters => InternalBaseParams, Parameters => InternalParams}
@@ -35,8 +34,8 @@ object Parameters {
             isSample: Boolean,
             fileLimit: Int,
             fedoraClient: FedoraClient,
-            ldapContext: LdapContext,
+            ldapEnv: LdapEnv,
             fsrdb: (String, String, String)): InternalParams = {
-    new internal.Parameters(templateResourceDir, datasetID, isSample, fileLimit, fedoraClient, ldapContext, fsrdb)
+    new internal.Parameters(templateResourceDir, datasetID, isSample, fileLimit, fedoraClient, ldapEnv, fsrdb)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
@@ -43,11 +43,16 @@ case class Parameters(override val templateResourceDir: File,
                       fedora: Fedora,
                       ldap: Ldap,
                       fsrdb: Connection)
-  extends BaseParameters(templateResourceDir, datasetID, isSample, fileLimit) with DatabaseParameters {
+  extends BaseParameters(templateResourceDir, datasetID, isSample, fileLimit) with DatabaseParameters with AutoCloseable {
 
   def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fileLimit: Int, fedoraClient: FedoraClient, ldapEnv: LdapEnv, fsrdb: (String, String, String)) = {
     this(templateResourceDir, datasetID, isSample, fileLimit, FedoraImpl(fedoraClient), LdapImpl(new InitialLdapContext(ldapEnv, null)), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3))
   }
+
+    override def close(): Unit = {
+      fsrdb.close()
+      ldap.close()
+    }
 
   override def toString: String = super.toString
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/internal/Parameters.scala
@@ -17,10 +17,10 @@ package nl.knaw.dans.easy.license.internal
 
 import java.io.File
 import java.sql.{ Connection, DriverManager }
-import javax.naming.ldap.LdapContext
 
+import javax.naming.ldap.InitialLdapContext
 import com.yourmediashelf.fedora.client.FedoraClient
-import nl.knaw.dans.easy.license.DatasetID
+import nl.knaw.dans.easy.license.{ DatasetID, LdapEnv }
 
 // this class needs to be in a separate file rather than in package.scala because of interop with
 // java business layer.
@@ -45,8 +45,8 @@ case class Parameters(override val templateResourceDir: File,
                       fsrdb: Connection)
   extends BaseParameters(templateResourceDir, datasetID, isSample, fileLimit) with DatabaseParameters {
 
-  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fileLimit: Int, fedoraClient: FedoraClient, ldapContext: LdapContext, fsrdb: (String, String, String)) = {
-    this(templateResourceDir, datasetID, isSample, fileLimit, FedoraImpl(fedoraClient), LdapImpl(ldapContext), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3))
+  def this(templateResourceDir: File, datasetID: DatasetID, isSample: Boolean, fileLimit: Int, fedoraClient: FedoraClient, ldapEnv: LdapEnv, fsrdb: (String, String, String)) = {
+    this(templateResourceDir, datasetID, isSample, fileLimit, FedoraImpl(fedoraClient), LdapImpl(new InitialLdapContext(ldapEnv, null)), DriverManager.getConnection(fsrdb._1, fsrdb._2, fsrdb._3))
   }
 
   override def toString: String = super.toString

--- a/src/main/scala/nl.knaw.dans.easy.license/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/package.scala
@@ -17,19 +17,36 @@ package nl.knaw.dans.easy
 
 import java.io.Closeable
 
+import javax.naming.ldap.{ InitialLdapContext, LdapContext }
 import org.apache.commons.io.IOUtils
 import rx.lang.scala.Observable
-
-import scala.util.{ Failure, Success, Try }
 
 package object license {
 
   type DatasetID = String
   type DepositorID = String
+  type LdapConnectControls = java.util.Hashtable[String, String]
 
   implicit class ReactiveResourceManager[T <: Closeable](val resource: T) extends AnyVal {
     def usedIn[S](observableFactory: T => Observable[S], dispose: T => Unit = _ => {}, disposeEagerly: Boolean = false): Observable[S] = {
       Observable.using(resource)(observableFactory, t => { dispose(t); IOUtils.closeQuietly(t) }, disposeEagerly)
     }
   }
+
+  def getLdapConnection(ldapConnectControls: LdapConnectControls) : LdapContext = {
+    new InitialLdapContext(ldapConnectControls, null)
+  }
+
+//  def getLdapConnection(ldapConnectControls: LdapConnectControls) : Unit = {
+//    val ldapContext = Try {new InitialLdapContext(ldapConnectControls, null)}
+//    ldapContext.map {
+//      context => ldapContext.get.close()
+//    }.recoverWith {
+//      case t: AuthenticationException => Success(false)
+//      case t =>
+//        log.debug("Unexpected exception", t)
+//        Failure(new RuntimeException("Error trying to authenticate", t))
+//    }
+//  }
+
 }

--- a/src/main/scala/nl.knaw.dans.easy.license/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.license/package.scala
@@ -25,28 +25,11 @@ package object license {
 
   type DatasetID = String
   type DepositorID = String
-  type LdapConnectControls = java.util.Hashtable[String, String]
+  type LdapEnv = java.util.Hashtable[String, String]
 
   implicit class ReactiveResourceManager[T <: Closeable](val resource: T) extends AnyVal {
     def usedIn[S](observableFactory: T => Observable[S], dispose: T => Unit = _ => {}, disposeEagerly: Boolean = false): Observable[S] = {
       Observable.using(resource)(observableFactory, t => { dispose(t); IOUtils.closeQuietly(t) }, disposeEagerly)
     }
   }
-
-  def getLdapConnection(ldapConnectControls: LdapConnectControls) : LdapContext = {
-    new InitialLdapContext(ldapConnectControls, null)
-  }
-
-//  def getLdapConnection(ldapConnectControls: LdapConnectControls) : Unit = {
-//    val ldapContext = Try {new InitialLdapContext(ldapConnectControls, null)}
-//    ldapContext.map {
-//      context => ldapContext.get.close()
-//    }.recoverWith {
-//      case t: AuthenticationException => Success(false)
-//      case t =>
-//        log.debug("Unexpected exception", t)
-//        Failure(new RuntimeException("Error trying to authenticate", t))
-//    }
-//  }
-
 }


### PR DESCRIPTION
fixes EASY-1727

#### When applied it will
* create LDAP-connection every time anew when needed; originally LDAP-connection was created only once when starting the service.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
